### PR TITLE
Rafactor/use magic enum

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -22,6 +22,7 @@
       <file path="$PROJECT_DIR$/Externals/FMT" />
       <file path="$PROJECT_DIR$/Externals/FreeType2" />
       <file path="$PROJECT_DIR$/Externals/IttApi" />
+      <file path="$PROJECT_DIR$/Externals/MagicEnum" />
       <file path="$PROJECT_DIR$/Externals/OpenImageIO" />
       <file path="$PROJECT_DIR$/Externals/PerlinNoise" />
       <file path="$PROJECT_DIR$/Externals/SPIRV" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -15,8 +15,11 @@
     <mapping directory="$PROJECT_DIR$/Externals/FMT" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/Externals/FreeType2" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/Externals/IttApi" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/Externals/MagicEnum" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/Externals/STB" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/Externals/TaskFlow" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/Externals/Tracy" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/Externals/Tracy/vcpkg/vcpkg" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/Externals/Tracy/vcpkg/vcpkg/downloads/git-tmp" vcs="Git" />
   </component>
 </project>

--- a/Apps/Common/CMakeLists.txt
+++ b/Apps/Common/CMakeLists.txt
@@ -22,4 +22,5 @@ target_link_libraries(${TARGET}
     INTERFACE
         MethaneGraphicsApp
         MethaneBuildOptions
+        magic_enum
 )

--- a/Apps/Common/Include/Methane/Samples/AppSettings.hpp
+++ b/Apps/Common/Include/Methane/Samples/AppSettings.hpp
@@ -25,6 +25,8 @@ Common application settings for Methane samples and tutorials.
 
 #include <Methane/Graphics/App.hpp>
 
+#include <magic_enum.hpp>
+
 namespace Methane::Samples
 {
 
@@ -37,6 +39,7 @@ constexpr bool g_is_apple = false;
 inline Graphics::AppSettings GetGraphicsAppSettings(const std::string& app_name, bool animations_enabled = true, bool depth_enabled = true, float clear_depth = 1.F,
                                                     std::optional<Graphics::Color4f> clear_color = Graphics::Color4f(0.0F, 0.2F, 0.4F, 1.0F))
 {
+    using namespace magic_enum::bitwise_operators;
     using Stencil = Graphics::Stencil;
     using DepthStencilOpt = std::optional<Graphics::DepthStencil>;
     return Graphics::AppSettings

--- a/Apps/Samples/Asteroids/AsteroidsApp.cpp
+++ b/Apps/Samples/Asteroids/AsteroidsApp.cpp
@@ -33,6 +33,7 @@ Sample demonstrating parallel rendering of the distinct asteroids massive
 #include <thread>
 #include <array>
 #include <map>
+#include <magic_enum.hpp>
 
 namespace Methane::Samples
 {
@@ -194,6 +195,7 @@ void AsteroidsApp::Init()
     m_view_camera.Resize(float_rect_size);
 
     // Create sky-box
+    using namespace magic_enum::bitwise_operators;
     m_sky_box_ptr = std::make_shared<gfx::SkyBox>(context, GetImageLoader(), gfx::SkyBox::Settings{
         m_view_camera,
         {

--- a/Apps/Samples/Asteroids/AsteroidsAppController.h
+++ b/Apps/Samples/Asteroids/AsteroidsAppController.h
@@ -31,18 +31,15 @@ namespace Methane::Samples
 
 class AsteroidsApp;
 
-enum class AsteroidsAppAction : uint32_t
+enum class AsteroidsAppAction
 {
-    None = 0U,
-
+    None,
     IncreaseComplexity,
     DecreaseComplexity,
     SwitchParallelRendering,
     SwitchMeshLodsColoring,
     IncreaseMeshLodComplexity,
-    DecreaseMeshLodComplexity,
-
-    Count
+    DecreaseMeshLodComplexity
 };
 
 class AsteroidsAppController final

--- a/Apps/Samples/Asteroids/Planet.h
+++ b/Apps/Samples/Asteroids/Planet.h
@@ -53,7 +53,7 @@ public:
         float                           scale;
         float                           spin_velocity_rps   = 0.3F; // (rps = radians per second)
         bool                            depth_reversed      = false;
-        gfx::ImageLoader::Options::Mask image_options       = gfx::ImageLoader::Options::None;
+        gfx::ImageLoader::Options image_options       = gfx::ImageLoader::Options::None;
         float                           lod_bias            = 0.F;
     };
 

--- a/Apps/Tutorials/02-TexturedCube/README.md
+++ b/Apps/Tutorials/02-TexturedCube/README.md
@@ -264,7 +264,7 @@ void TexturedCubeApp::Init()
 Cube face texture is created using `Graphics::ImageLoader` class through the instance provided by 
 `Graphics::App::GetImageLoader()` function. Texture is loaded from embedded JPEG image from application resources
 by path in embedded file system `Textures/MethaneBubbles.jpg`. Image is added to application resources in build time and
-[configured in CMakeLists.txt](#cmake-build-configuration). `Graphics::ImageLoader::Options::Mask` is passed to
+[configured in CMakeLists.txt](#cmake-build-configuration). `Graphics::ImageLoader::Options` is passed to
 image loading function to request mipmaps generation and using SRGB texture format.
 
 Sampler object is created with `Graphics::Sampler::Create(...)` factory function which defines
@@ -276,7 +276,7 @@ void TexturedCubeApp::Init()
     ...
 
     // Load texture image from file
-    const gfx::ImageLoader::Options::Mask image_options = gfx::ImageLoader::Options::Mipmapped
+    const gfx::ImageLoader::Options image_options = gfx::ImageLoader::Options::Mipmapped
                                                         | gfx::ImageLoader::Options::SrgbColorSpace;
     m_cube_texture_ptr = GetImageLoader().LoadImageToTexture2D(GetRenderContext(), "Textures/MethaneBubbles.jpg", image_options);
     m_cube_texture_ptr->SetName("Cube Texture 2D Image");

--- a/Apps/Tutorials/02-TexturedCube/TexturedCubeApp.cpp
+++ b/Apps/Tutorials/02-TexturedCube/TexturedCubeApp.cpp
@@ -27,6 +27,7 @@ Tutorial demonstrating textured cube rendering with Methane graphics API
 #include <Methane/Graphics/Mesh/CubeMesh.hpp>
 #include <Methane/Data/TimeAnimation.h>
 
+#include <magic_enum.hpp>
 #include <cml/mathlib/mathlib.h>
 
 namespace Methane::Tutorials
@@ -120,8 +121,9 @@ void TexturedCubeApp::Init()
     m_render_state_ptr->SetName("Final FB Render Pipeline State");
 
     // Load texture image from file
-    const gfx::ImageLoader::Options::Mask image_options = gfx::ImageLoader::Options::Mipmapped
-                                                        | gfx::ImageLoader::Options::SrgbColorSpace;
+    using namespace magic_enum::bitwise_operators;
+    const gfx::ImageLoader::Options image_options = gfx::ImageLoader::Options::Mipmapped
+                                                  | gfx::ImageLoader::Options::SrgbColorSpace;
     m_cube_texture_ptr = GetImageLoader().LoadImageToTexture2D(GetRenderContext(), "Textures/MethaneBubbles.jpg", image_options);
     m_cube_texture_ptr->SetName("Cube Texture 2D Image");
 

--- a/Apps/Tutorials/03-ShadowCube/ShadowCubeApp.cpp
+++ b/Apps/Tutorials/03-ShadowCube/ShadowCubeApp.cpp
@@ -28,6 +28,7 @@ Tutorial demonstrating shadow-pass rendering with Methane graphics API
 #include <Methane/Data/TimeAnimation.h>
 
 #include <cml/mathlib/mathlib.h>
+#include <magic_enum.hpp>
 
 namespace Methane::Tutorials
 {
@@ -94,8 +95,9 @@ void ShadowCubeApp::Init()
     const gfx::QuadMesh<Vertex>   floor_mesh(mesh_layout, 7.F, 7.F, 0.F, 0, gfx::QuadMesh<Vertex>::FaceType::XZ);
 
     // Load textures, vertex and index buffers for cube and floor meshes
-    const gfx::ImageLoader::Options::Mask image_options = gfx::ImageLoader::Options::Mipmapped
-                                                        | gfx::ImageLoader::Options::SrgbColorSpace;
+    using namespace magic_enum::bitwise_operators;
+    const gfx::ImageLoader::Options image_options = gfx::ImageLoader::Options::Mipmapped
+                                                  | gfx::ImageLoader::Options::SrgbColorSpace;
 
     m_cube_buffers_ptr  = std::make_unique<TexturedMeshBuffers>(GetRenderContext(), cube_mesh, "Cube");
     m_cube_buffers_ptr->SetTexture(GetImageLoader().LoadImageToTexture2D(GetRenderContext(), "Textures/MethaneBubbles.jpg", image_options));
@@ -180,7 +182,8 @@ void ShadowCubeApp::Init()
     m_final_pass.view_state_ptr = GetViewStatePtr();
 
     // ========= Shadow Pass objects =========
-    
+
+    using namespace magic_enum::bitwise_operators;
     gfx::Texture::Settings shadow_texture_settings = gfx::Texture::Settings::DepthStencilBuffer(
         gfx::Dimensions(g_shadow_map_size),
         context_settings.depth_stencil_format,

--- a/Apps/Tutorials/04-Typography/TypographyApp.cpp
+++ b/Apps/Tutorials/04-Typography/TypographyApp.cpp
@@ -27,6 +27,7 @@ Tutorial demonstrating dynamic text rendering and fonts management with Methane 
 #include <Methane/Samples/AppSettings.hpp>
 #include <Methane/Data/TimeAnimation.h>
 
+#include <magic_enum.hpp>
 #include <array>
 
 namespace Methane::Tutorials
@@ -457,9 +458,9 @@ std::string TypographyApp::GetParametersString()
 {
     std::stringstream ss;
     ss << "Typography parameters:"
-       << std::endl << "  - text wrap mode:            " << gui::Text::GetWrapName(m_settings.text_layout.wrap)
-       << std::endl << "  - horizontal text alignment: " << gui::Text::GetHorizontalAlignmentName(m_settings.text_layout.horizontal_alignment)
-       << std::endl << "  - vertical text alignment:   " << gui::Text::GetVerticalAlignmentName(m_settings.text_layout.vertical_alignment)
+       << std::endl << "  - text wrap mode:            " << magic_enum::enum_name(m_settings.text_layout.wrap)
+       << std::endl << "  - horizontal text alignment: " << magic_enum::enum_name(m_settings.text_layout.horizontal_alignment)
+       << std::endl << "  - vertical text alignment:   " << magic_enum::enum_name(m_settings.text_layout.vertical_alignment)
        << std::endl << "  - text typing mode:          " << (m_settings.is_forward_typing_direction ? "Appending" : "Backspace")
        << std::endl << "  - text typing interval (ms): " << static_cast<uint32_t>(m_settings.typing_update_interval_sec * 1000)
        << std::endl << "  - text typing animation:     " << (!GetAnimations().IsPaused() ? "ON" : "OFF")

--- a/Apps/Tutorials/04-Typography/TypographyAppController.cpp
+++ b/Apps/Tutorials/04-Typography/TypographyAppController.cpp
@@ -53,17 +53,17 @@ void TypographyAppController::OnKeyboardStateAction(TypographyAppAction action)
     switch(action)
     {
     case TypographyAppAction::SwitchTextWrapMode:
-        text_layout.wrap = static_cast<gui::Text::Wrap>((static_cast<uint32_t>(text_layout.wrap) + 1) % 3);
+        text_layout.wrap = magic_enum::enum_value<gui::Text::Wrap>((magic_enum::enum_integer(text_layout.wrap) + 1) % 3);
         m_typography_app.SetTextLayout(text_layout);
         break;
 
     case TypographyAppAction::SwitchTextHorizontalAlignment:
-        text_layout.horizontal_alignment = static_cast<gui::Text::HorizontalAlignment>((static_cast<uint32_t>(text_layout.horizontal_alignment) + 1) % 3);
+        text_layout.horizontal_alignment = magic_enum::enum_value<gui::Text::HorizontalAlignment>((magic_enum::enum_integer(text_layout.horizontal_alignment) + 1) % 3);
         m_typography_app.SetTextLayout(text_layout);
         break;
 
     case TypographyAppAction::SwitchTextVerticalAlignment:
-        text_layout.vertical_alignment = static_cast<gui::Text::VerticalAlignment>((static_cast<uint32_t>(text_layout.vertical_alignment) + 1) % 3);
+        text_layout.vertical_alignment = magic_enum::enum_value<gui::Text::VerticalAlignment>((magic_enum::enum_integer(text_layout.vertical_alignment) + 1) % 3);
         m_typography_app.SetTextLayout(text_layout);
         break;
 

--- a/Apps/Tutorials/04-Typography/TypographyAppController.h
+++ b/Apps/Tutorials/04-Typography/TypographyAppController.h
@@ -31,19 +31,16 @@ namespace Methane::Tutorials
 
 class TypographyApp;
 
-enum class TypographyAppAction : uint32_t
+enum class TypographyAppAction
 {
-    None = 0U,
-
+    None,
     SwitchTextWrapMode,
     SwitchTextHorizontalAlignment,
     SwitchTextVerticalAlignment,
     SwitchIncrementalTextUpdate,
     SwitchTypingDirection,
     SpeedupTyping,
-    SlowdownTyping,
-
-    Count
+    SlowdownTyping
 };
 
 class TypographyAppController final

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,8 @@ set(CMAKE_DISABLE_FIND_PACKAGE_HHC TRUE)
 set(CMAKE_DISABLE_FIND_PACKAGE_LATEX TRUE)
 set(CMAKE_DISABLE_FIND_PACKAGE_Perl TRUE)
 
+set(MAGIC_ENUM_OPT_INSTALL ON CACHE BOOL "Generate and install magic_enum target")
+
 add_subdirectory(Externals)
 add_subdirectory(Modules)
 

--- a/Modules/Common/Instrumentation/Include/Methane/IttApiHelper.h
+++ b/Modules/Common/Instrumentation/Include/Methane/IttApiHelper.h
@@ -16,7 +16,7 @@ limitations under the License.
 
 *******************************************************************************
 
-FILE: Methane/IttNotifyHelper.h
+FILE: Methane/IttApiHelper.h
 Helper macro-definitions for ITT instrumentation
 
 ******************************************************************************/
@@ -96,12 +96,12 @@ protected:
 class Marker : public Event
 {
 public:
-    enum Scope
+    enum class Scope : int
     {
         Global  = __itt_scope_global,
         Process = __itt_scope_track_group,
-        Thread  =__itt_scope_track,
-        Task    =__itt_scope_task, //means a task that will long until another marker with task scope in this thread occurs
+        Thread  = __itt_scope_track,
+        Task    = __itt_scope_task, //means a task that will long until another marker with task scope in this thread occurs
     };
 
     Marker(const __itt_domain* p_domain, const char* p_name, Scope scope) noexcept

--- a/Modules/Common/PrecompiledHeaders/CMakeLists.txt
+++ b/Modules/Common/PrecompiledHeaders/CMakeLists.txt
@@ -17,12 +17,14 @@ endif()
 
 set(PRECOMPILED_HEADERS ${PRECOMPILED_HEADERS}
     # Common Methane headers
+    $<TARGET_PROPERTY:MethanePrimitives,SOURCE_DIR>/Include/Methane/Memory.hpp
     $<TARGET_PROPERTY:MethanePrimitives,SOURCE_DIR>/Include/Methane/Checks.hpp
     $<TARGET_PROPERTY:MethaneInstrumentation,SOURCE_DIR>/Include/Methane/Instrumentation.h
 
     # Common External headers
     <fmt/format.h>
     <nowide/convert.hpp>
+    <magic_enum.hpp>
 
     # types
     <limits>
@@ -63,6 +65,7 @@ target_link_libraries(${TARGET}
         MethaneInstrumentation
         fmt
         nowide
+        magic_enum
 )
 
 target_precompile_headers(${TARGET}
@@ -107,6 +110,9 @@ target_link_libraries(${EXTRA_TARGET}
         MethaneInstrumentation
         TaskFlow
         CML
+        fmt
+        nowide
+        magic_enum
         ${PLATFORM_LIBRARIES}
 )
 

--- a/Modules/Graphics/App/Include/Methane/Graphics/App.h
+++ b/Modules/Graphics/App/Include/Methane/Graphics/App.h
@@ -23,6 +23,8 @@ Interface of the graphics application base template class defined in App.hpp
 
 #pragma once
 
+#include <Methane/Graphics/RenderPass.h>
+
 #include <stdint.h>
 
 namespace Methane::Graphics
@@ -32,10 +34,10 @@ struct IApp
 {
     struct Settings
     {
-        uint32_t screen_pass_access         = 0U;   // Graphics::RenderPass::Access::Mask
-        bool     animations_enabled         = true;
-        bool     show_hud_in_window_title   = true;
-        int32_t  default_device_index       = 0;    // 0 - default h/w GPU, 1 - second h/w GPU, -1 - emulated WARP device
+        RenderPass::Access screen_pass_access         = RenderPass::Access::None;
+        bool               animations_enabled         = true;
+        bool               show_hud_in_window_title   = true;
+        int32_t            default_device_index       = 0;    // 0 - default h/w GPU, 1 - second h/w GPU, -1 - emulated WARP device
     };
 
     virtual const Settings& GetGraphicsAppSettings() const noexcept = 0;

--- a/Modules/Graphics/App/Include/Methane/Graphics/AppContextController.h
+++ b/Modules/Graphics/App/Include/Methane/Graphics/AppContextController.h
@@ -33,16 +33,13 @@ namespace Methane::Graphics
 
 struct RenderContext;
 
-enum class AppContextAction : uint32_t
+enum class AppContextAction
 {
-    None = 0,
-
+    None,
     SwitchVSync,
     SwitchDevice,
     AddFrameBufferToSwapChain,
-    RemoveFrameBufferFromSwapChain,
-    
-    Count
+    RemoveFrameBufferFromSwapChain
 };
 
 class AppContextController final

--- a/Modules/Graphics/App/Include/Methane/Graphics/AppController.h
+++ b/Modules/Graphics/App/Include/Methane/Graphics/AppController.h
@@ -33,11 +33,8 @@ namespace Methane::Graphics
 
 enum class AppAction : uint32_t
 {
-    None = 0,
-
-    SwitchAnimations,
-
-    Count
+    None = 0U,
+    SwitchAnimations
 };
 
 class AppController

--- a/Modules/Graphics/App/README.md
+++ b/Modules/Graphics/App/README.md
@@ -13,7 +13,7 @@ The following settings are available:
 
 | IApp Setting             | Type     | Default Value | Cmd-Line Option | Description           |
 |--------------------------|----------|---------------|-----------------|-----------------------|
-| screen_pass_access       | uint32_t | 0             |                 | Render pass access mask Graphics::RenderPass::Access::Mask |
+| screen_pass_access       | uint32_t | 0             |                 | Render pass access mask Graphics::RenderPass::Access |
 | animations_enabled       | bool     | true          | -a,--animations | Flag to enable or disable all animations |
 | show_hud_in_window_title | bool     | true          |                 | Flag to display or hide graphics runtime parameters in window title |         
 | default_device_index     | int32_t  | 0             | -d,--device     | Default GPU device used at startup: 0 - default h/w GPU, 1 - second h/w GPU, -1 - emulated WARP device |

--- a/Modules/Graphics/App/Sources/Methane/Graphics/AppBase.cpp
+++ b/Modules/Graphics/App/Sources/Methane/Graphics/AppBase.cpp
@@ -236,29 +236,29 @@ Ptr<RenderPass> AppBase::CreateScreenRenderPass(const Ptr<Texture>& frame_buffer
                 {
                     frame_buffer_texture, 0, 0, 0,
                     context_settings.clear_color.has_value()
-                    ? RenderPass::Attachment::LoadAction::Clear
-                    : RenderPass::Attachment::LoadAction::DontCare,
+                        ? RenderPass::Attachment::LoadAction::Clear
+                        : RenderPass::Attachment::LoadAction::DontCare,
                     RenderPass::Attachment::StoreAction::Store,
                 },
                 context_settings.clear_color
-                ? *context_settings.clear_color
-                : Color4f()
+                    ? *context_settings.clear_color
+                    : Color4f()
             )
         },
         RenderPass::DepthAttachment(
             {
                 m_depth_texture_ptr, 0, 0, 0,
                 context_settings.clear_depth_stencil.has_value()
-                ? RenderPass::Attachment::LoadAction::Clear
-                : RenderPass::Attachment::LoadAction::DontCare,
+                    ? RenderPass::Attachment::LoadAction::Clear
+                    : RenderPass::Attachment::LoadAction::DontCare,
                 RenderPass::Attachment::StoreAction::DontCare,
             },
             context_settings.clear_depth_stencil
-            ? context_settings.clear_depth_stencil->first
-            : 1.F
+                ? context_settings.clear_depth_stencil->first
+                : 1.F
         ),
         RenderPass::StencilAttachment(),
-        m_settings.screen_pass_access,
+        static_cast<RenderPass::Access>(m_settings.screen_pass_access),
         true // final render pass
     });
 }

--- a/Modules/Graphics/App/Sources/Methane/Graphics/AppBase.cpp
+++ b/Modules/Graphics/App/Sources/Methane/Graphics/AppBase.cpp
@@ -258,7 +258,7 @@ Ptr<RenderPass> AppBase::CreateScreenRenderPass(const Ptr<Texture>& frame_buffer
                 : 1.F
         ),
         RenderPass::StencilAttachment(),
-        static_cast<RenderPass::Access>(m_settings.screen_pass_access),
+        m_settings.screen_pass_access,
         true // final render pass
     });
 }

--- a/Modules/Graphics/Camera/Include/Methane/Graphics/ActionCamera.h
+++ b/Modules/Graphics/Camera/Include/Methane/Graphics/ActionCamera.h
@@ -36,21 +36,17 @@ namespace Methane::Graphics
 class ActionCamera : public ArcBallCamera
 {
 public:
-    enum class MouseAction : uint32_t
+    enum class MouseAction
     {
-        None = 0,
-
+        None,
         Rotate,
         Move,
-        Zoom,
-
-        // Keep at end
-        Count
+        Zoom
     };
 
-    enum class KeyboardAction : uint32_t
+    enum class KeyboardAction
     {
-        None = 0,
+        None,
 
         // Move
         MoveLeft,
@@ -74,10 +70,7 @@ public:
         
         // Other
         Reset,
-        ChangePivot,
-
-        // Keep at end
-        Count
+        ChangePivot
     };
 
     using DistanceRange = std::pair<float /*min_distance*/, float /*max_distance*/>;

--- a/Modules/Graphics/Core/CMakeLists.txt
+++ b/Modules/Graphics/Core/CMakeLists.txt
@@ -264,6 +264,8 @@ target_link_libraries(${TARGET}
         MethaneInstrumentation
         MethanePrecompiledExtraHeaders
         TaskFlow
+        nowide
+        magic_enum
         ${PLATFORM_LIBRARIES}
 )
 

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Buffer.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Buffer.h
@@ -50,7 +50,7 @@ struct Buffer : virtual Resource
     struct Settings
     {
         Buffer::Type type;
-        Usage::Mask  usage_mask;
+        Usage        usage_mask;
         Data::Size   size;
         Data::Size   item_stride_size;
         PixelFormat  data_format;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Buffer.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Buffer.h
@@ -66,7 +66,6 @@ struct Buffer : virtual Resource
 
     // Auxiliary functions
     static Data::Size  GetAlignedBufferSize(Data::Size size) noexcept;
-    static std::string GetBufferTypeName(Type type);
 
     // Buffer interface
     virtual const Settings& GetSettings() const noexcept = 0;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/CommandList.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/CommandList.h
@@ -39,16 +39,16 @@ struct CommandQueue;
 
 struct CommandList : virtual Object
 {
-    enum class Type : uint32_t
+    enum class Type
     {
-        Blit = 0U,
+        Blit,
         Render,
         ParallelRender,
     };
 
-    enum State : uint32_t
+    enum class State
     {
-        Pending = 0U,
+        Pending,
         Encoding,
         Committed,
         Executing,
@@ -61,8 +61,6 @@ struct CommandList : virtual Object
         virtual DebugGroup& AddSubGroup(Data::Index id, const std::string& name) = 0;
         virtual DebugGroup* GetSubGroup(Data::Index id) const noexcept = 0;
         virtual bool        HasSubGroups() const noexcept = 0;
-
-        virtual ~DebugGroup() = default;
     };
 
     using CompletedCallback = std::function<void(CommandList& command_list)>;
@@ -79,8 +77,6 @@ struct CommandList : virtual Object
     virtual void  WaitUntilCompleted(uint32_t timeout_ms = 0U) = 0;
     virtual Data::TimeRange GetGpuTimeRange(bool in_cpu_nanoseconds) const = 0;
     virtual CommandQueue& GetCommandQueue() = 0;
-
-    virtual ~CommandList() = default;
 };
 
 struct CommandListSet

--- a/Modules/Graphics/Core/Include/Methane/Graphics/CommandList.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/CommandList.h
@@ -74,7 +74,7 @@ struct CommandList : virtual Object
     virtual void  PopDebugGroup() = 0;
     virtual void  Reset(DebugGroup* p_debug_group = nullptr) = 0;
     virtual void  SetProgramBindings(ProgramBindings& program_bindings,
-                                     ProgramBindings::ApplyBehavior::Mask apply_behavior = ProgramBindings::ApplyBehavior::AllIncremental) = 0;
+                                     ProgramBindings::ApplyBehavior apply_behavior = ProgramBindings::ApplyBehavior::AllIncremental) = 0;
     virtual void  Commit() = 0;
     virtual void  WaitUntilCompleted(uint32_t timeout_ms = 0U) = 0;
     virtual Data::TimeRange GetGpuTimeRange(bool in_cpu_nanoseconds) const = 0;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Device.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Device.h
@@ -49,30 +49,17 @@ struct Device
     : virtual Object
     , virtual Data::IEmitter<IDeviceCallback>
 {
-    struct Feature
+    enum class Features : uint32_t
     {
-        using Mask = uint32_t;
-        enum Value : Mask
-        {
-            Unknown                 = 0U,
-            BasicRendering          = 1U << 0U,
-            TextureAndSamplerArrays = 1U << 1U,
-            All                     = ~0U,
-        };
-
-        using Values = std::array<Value, 2>;
-        static constexpr const Values values{ BasicRendering, TextureAndSamplerArrays };
-        
-        static std::string ToString(Value feature);
-        static std::string ToString(Mask features);
-
-        Feature()  = delete;
-        ~Feature() = delete;
+        Unknown                 = 0U,
+        BasicRendering          = 1U << 0U,
+        TextureAndSamplerArrays = 1U << 1U,
+        All                     = ~0U,
     };
 
     virtual const std::string& GetAdapterName() const noexcept = 0;
     virtual bool               IsSoftwareAdapter() const noexcept = 0;
-    virtual Feature::Mask      GetSupportedFeatures() const noexcept = 0;
+    virtual Features           GetSupportedFeatures() const noexcept = 0;
     virtual std::string        ToString() const = 0;
 };
 
@@ -80,13 +67,13 @@ struct System
 {
     static System& Get();
 
-    virtual void                  CheckForChanges() = 0;
-    virtual const Ptrs<Device>&   UpdateGpuDevices(Device::Feature::Mask supported_features = Device::Feature::Value::All) = 0;
-    virtual const Ptrs<Device>&   GetGpuDevices() const = 0;
-    virtual Ptr<Device>           GetNextGpuDevice(const Device& device) const = 0;
-    virtual Ptr<Device>           GetSoftwareGpuDevice() const = 0;
-    virtual Device::Feature::Mask GetGpuSupportedFeatures() const = 0;
-    virtual std::string           ToString() const = 0;
+    virtual void                CheckForChanges() = 0;
+    virtual const Ptrs<Device>& UpdateGpuDevices(Device::Features supported_features = Device::Features::All) = 0;
+    virtual const Ptrs<Device>& GetGpuDevices() const = 0;
+    virtual Ptr<Device>         GetNextGpuDevice(const Device& device) const = 0;
+    virtual Ptr<Device>         GetSoftwareGpuDevice() const = 0;
+    virtual Device::Features    GetGpuSupportedFeatures() const = 0;
+    virtual std::string         ToString() const = 0;
     
     virtual ~System() = default;
 };

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Program.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Program.h
@@ -78,18 +78,12 @@ struct Program : virtual Object
             const UniquePtr<Argument> m_argument_ptr;
         };
 
-        struct Modifiers
+        enum class Modifiers : uint32_t
         {
-            using Mask = uint32_t;
-            enum Value : Mask
-            {
-                None        = 0U,
-                Constant    = 1U << 0U,
-                Addressable = 1U << 1U,
-                All         = ~0U,
-            };
-
-            Modifiers() = delete;
+            None        = 0U,
+            Constant    = 1U << 0U,
+            Addressable = 1U << 1U,
+            All         = ~0U
         };
 
         const Shader::Type shader_type;
@@ -113,17 +107,17 @@ struct Program : virtual Object
 
     struct ArgumentDesc : Argument
     {
-        const Modifiers::Mask modifiers;
+        const Modifiers modifiers;
 
         ArgumentDesc(Shader::Type shader_type, const std::string& argument_name,
-                     Modifiers::Mask modifiers_mask = Modifiers::None) noexcept;
+                     Modifiers modifiers_mask = Modifiers::None) noexcept;
         ArgumentDesc(const Argument& argument,
-                     Modifiers::Mask modifiers_mask = Modifiers::None) noexcept;
+                     Modifiers modifiers_mask = Modifiers::None) noexcept;
         ArgumentDesc(const ArgumentDesc& argument_desc) = default;
         ArgumentDesc(ArgumentDesc&& argument_desc) noexcept = default;
 
-        inline bool IsConstant() const    { return modifiers & Modifiers::Constant; }
-        inline bool IsAddressable() const { return modifiers & Modifiers::Addressable; }
+        inline bool IsConstant() const    { return static_cast<uint32_t>(modifiers) & static_cast<uint32_t>(Modifiers::Constant); }
+        inline bool IsAddressable() const { return static_cast<uint32_t>(modifiers) & static_cast<uint32_t>(Modifiers::Addressable); }
     };
 
     using ArgumentDescriptions = std::unordered_set<ArgumentDesc, ArgumentDesc::Hash>;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Program.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Program.h
@@ -141,8 +141,6 @@ struct Program : virtual Object
     virtual const Settings&      GetSettings() const = 0;
     virtual const Shader::Types& GetShaderTypes() const = 0;
     virtual const Ptr<Shader>&   GetShader(Shader::Type shader_type) const = 0;
-
-    virtual ~Program() = default;
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Program.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Program.h
@@ -30,6 +30,7 @@ pipeline via state object and used to create resource binding objects.
 #include <Methane/Memory.hpp>
 #include <Methane/Graphics/Types.h>
 
+#include <magic_enum.hpp>
 #include <vector>
 #include <string>
 #include <unordered_set>
@@ -116,8 +117,8 @@ struct Program : virtual Object
         ArgumentDesc(const ArgumentDesc& argument_desc) = default;
         ArgumentDesc(ArgumentDesc&& argument_desc) noexcept = default;
 
-        inline bool IsConstant() const    { return static_cast<uint32_t>(modifiers) & static_cast<uint32_t>(Modifiers::Constant); }
-        inline bool IsAddressable() const { return static_cast<uint32_t>(modifiers) & static_cast<uint32_t>(Modifiers::Addressable); }
+        inline bool IsConstant() const    { using namespace magic_enum::bitwise_operators; return magic_enum::flags::enum_contains(modifiers & Modifiers::Constant); }
+        inline bool IsAddressable() const { using namespace magic_enum::bitwise_operators; return magic_enum::flags::enum_contains(modifiers & Modifiers::Addressable); }
     };
 
     using ArgumentDescriptions = std::unordered_set<ArgumentDesc, ArgumentDesc::Hash>;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/ProgramBindings.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/ProgramBindings.h
@@ -63,19 +63,13 @@ struct ProgramBindings
 
     using ArgumentBindings = std::unordered_map<Program::Argument, Ptr<ProgramBindings::ArgumentBinding>, Program::Argument::Hash>;
 
-    struct ApplyBehavior
+    enum class ApplyBehavior : uint32_t
     {
-        using Mask = uint32_t;
-        enum Value : Mask
-        {
-            Indifferent    = 0U,        // All bindings will be applied indifferently of the previous binding values
-            ConstantOnce   = 1U << 0,   // Constant program arguments will be applied only once for each command list
-            ChangesOnly    = 1U << 1,   // Only changed program argument values will be applied in command sequence
-            StateBarriers  = 1U << 2,   // Resource state barriers will be automatically evaluated and set for command list
-            AllIncremental = ~0U        // All binding values will be applied incrementally along with resource state barriers
-        };
-
-        ApplyBehavior() = delete;
+        Indifferent    = 0U,        // All bindings will be applied indifferently of the previous binding values
+        ConstantOnce   = 1U << 0,   // Constant program arguments will be applied only once for each command list
+        ChangesOnly    = 1U << 1,   // Only changed program argument values will be applied in command sequence
+        StateBarriers  = 1U << 2,   // Resource state barriers will be automatically evaluated and set for command list
+        AllIncremental = ~0U        // All binding values will be applied incrementally along with resource state barriers
     };
 
     using ResourceLocationsByArgument = std::unordered_map<Program::Argument, Resource::Locations, Program::Argument::Hash>;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/RenderCommandList.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/RenderCommandList.h
@@ -55,7 +55,7 @@ struct RenderCommandList : virtual CommandList
     virtual void SetValidationEnabled(bool is_validation_enabled) = 0;
     virtual RenderPass& GetRenderPass() const noexcept = 0;
     virtual void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) = 0;
-    virtual void SetRenderState(RenderState& render_state, RenderState::Group::Mask state_groups = RenderState::Group::All) = 0;
+    virtual void SetRenderState(RenderState& render_state, RenderState::Groups state_groups = RenderState::Groups::All) = 0;
     virtual void SetViewState(ViewState& view_state) = 0;
     virtual void SetVertexBuffers(BufferSet& vertex_buffers) = 0;
     virtual void DrawIndexed(Primitive primitive, Buffer& index_buffer, 

--- a/Modules/Graphics/Core/Include/Methane/Graphics/RenderPass.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/RenderPass.h
@@ -96,21 +96,14 @@ struct RenderPass : virtual Object
         bool operator==(const StencilAttachment& other) const;
     };
 
-    struct Access
+    enum class Access : uint32_t
     {
-        using Mask = uint32_t;
-        enum Value : Mask
-        {
-            None            = 0U,
-            ShaderResources = 1U << 0U,
-            Samplers        = 1U << 1U,
-            RenderTargets   = 1U << 2U,
-            DepthStencil    = 1U << 3U,
-            All             = ~0U,
-        };
-
-        using Values = std::array<Value, 4>;
-        static constexpr Values values{ ShaderResources, Samplers, RenderTargets, DepthStencil };
+        None            = 0U,
+        ShaderResources = 1U << 0U,
+        Samplers        = 1U << 1U,
+        RenderTargets   = 1U << 2U,
+        DepthStencil    = 1U << 3U,
+        All             = ~0U,
     };
 
     struct Settings
@@ -118,7 +111,7 @@ struct RenderPass : virtual Object
         ColorAttachments   color_attachments;
         DepthAttachment    depth_attachment;
         StencilAttachment  stencil_attachment;
-        Access::Mask       shader_access_mask = Access::None;
+        Access             shader_access_mask = Access::None;
         bool               is_final_pass = true;
 
         bool operator==(const Settings& other) const;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/RenderPass.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/RenderPass.h
@@ -125,8 +125,6 @@ struct RenderPass : virtual Object
     virtual const Settings& GetSettings() const = 0;
     virtual bool Update(const Settings& settings) = 0;
     virtual void ReleaseAttachmentTextures() = 0;
-
-    virtual ~RenderPass() = default;
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Include/Methane/Graphics/RenderState.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/RenderState.h
@@ -233,8 +233,6 @@ public:
     // RenderState interface
     virtual const Settings& GetSettings() const noexcept = 0;
     virtual void Reset(const Settings& settings) = 0;
-
-    virtual ~RenderState() = default;
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Include/Methane/Graphics/RenderState.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/RenderState.h
@@ -90,20 +90,14 @@ public:
 
     struct Blending
     {
-        struct ColorChannel
+        enum class ColorChannels : uint32_t
         {
-            using Mask = uint32_t;
-            enum Value : Mask
-            {
-                None    = 0U,
-                Red     = 1U << 0U,
-                Green   = 1U << 1U,
-                Blue    = 1U << 2U,
-                Alpha   = 1U << 3U,
-                All     = ~0U,
-            };
-
-            ColorChannel() = delete;
+            None    = 0U,
+            Red     = 1U << 0U,
+            Green   = 1U << 1U,
+            Blue    = 1U << 2U,
+            Alpha   = 1U << 3U,
+            All     = ~0U
         };
 
         enum class Operation : uint32_t
@@ -140,14 +134,14 @@ public:
 
         struct RenderTarget
         {
-            bool               blend_enabled             = false;
-            ColorChannel::Mask write_mask                = ColorChannel::All;
-            Operation          rgb_blend_op              = Operation::Add;
-            Operation          alpha_blend_op            = Operation::Add;
-            Factor             source_rgb_blend_factor   = Factor::One;
-            Factor             source_alpha_blend_factor = Factor::One;
-            Factor             dest_rgb_blend_factor     = Factor::Zero;
-            Factor             dest_alpha_blend_factor   = Factor::Zero;
+            bool          blend_enabled             = false;
+            ColorChannels write_mask                = ColorChannels::All;
+            Operation     rgb_blend_op              = Operation::Add;
+            Operation     alpha_blend_op            = Operation::Add;
+            Factor        source_rgb_blend_factor   = Factor::One;
+            Factor        source_alpha_blend_factor = Factor::One;
+            Factor        dest_rgb_blend_factor     = Factor::Zero;
+            Factor        dest_alpha_blend_factor   = Factor::Zero;
 
             bool operator==(const RenderTarget& other) const noexcept;
             bool operator!=(const RenderTarget& other) const noexcept;
@@ -207,21 +201,15 @@ public:
         bool operator!=(const Stencil& other) const noexcept;
     };
 
-    struct Group
+    enum class Groups : uint32_t
     {
-        using Mask = uint32_t;
-        enum Value : Mask
-        {
-            None                = 0U,
-            Program             = 1U << 0U,
-            Rasterizer          = 1U << 1U,
-            Blending            = 1U << 2U,
-            BlendingColor       = 1U << 3U,
-            DepthStencil        = 1U << 4U,
-            All                 = ~0U
-        };
-
-        Group() = delete;
+        None          = 0U,
+        Program       = 1U << 0U,
+        Rasterizer    = 1U << 1U,
+        Blending      = 1U << 2U,
+        BlendingColor = 1U << 3U,
+        DepthStencil  = 1U << 4U,
+        All           = ~0U
     };
 
     struct Settings
@@ -236,7 +224,7 @@ public:
         Blending     blending;
         Color4f      blending_color;
 
-        static Group::Mask Compare(const Settings& left, const Settings& right, Group::Mask compare_groups = Group::All) noexcept;
+        static Groups Compare(const Settings& left, const Settings& right, Groups compare_groups = Groups::All) noexcept;
     };
 
     // Create RenderState instance

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Resource.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Resource.h
@@ -32,6 +32,7 @@ Methane resource interface: base class of all GPU resources.
 
 #include <fmt/format.h>
 
+#include <magic_enum.hpp>
 #include <string>
 #include <vector>
 #include <map>
@@ -65,10 +66,11 @@ struct Resource : virtual Object
         Addressable  = 1U << 4U,
     };
 
-    static constexpr Usage s_secondary_usage_mask = static_cast<Usage>(
-        static_cast<uint32_t>(Usage::Addressable) |
-        static_cast<uint32_t>(Usage::ReadBack)
-    );
+    static constexpr Usage s_secondary_usage_mask = []() constexpr
+    {
+        using namespace magic_enum::bitwise_operators;
+        return Usage::Addressable | Usage::ReadBack;
+    }();
 
     struct Descriptor
     {

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Resource.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Resource.h
@@ -60,12 +60,15 @@ struct Resource : virtual Object
         ShaderRead   = 1U << 0U,
         ShaderWrite  = 1U << 1U,
         RenderTarget = 1U << 2U,
-        ReadBack     = 1U << 3U,
         // Secondary usages
+        ReadBack     = 1U << 3U,
         Addressable  = 1U << 4U,
     };
 
-    static constexpr Usage s_secondary_usage_mask = Usage::Addressable;
+    static constexpr Usage s_secondary_usage_mask = static_cast<Usage>(
+        static_cast<uint32_t>(Usage::Addressable) |
+        static_cast<uint32_t>(Usage::ReadBack)
+    );
 
     struct Descriptor
     {

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Resource.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Resource.h
@@ -118,9 +118,6 @@ struct Resource : virtual Object
         {
         public:
             explicit Count(Data::Size array_size  = 1U, Data::Size depth  = 1U, Data::Size mip_levels_count = 1U);
-            Count(const Count&) noexcept = default;
-
-            Count& operator=(const Count&) noexcept = default;
 
             Data::Size GetDepth() const noexcept          { return m_depth; }
             Data::Size GetArraySize() const noexcept      { return m_array_size; }
@@ -173,8 +170,6 @@ struct Resource : virtual Object
 
         using BytesRangeOpt = std::optional<BytesRange>;
 
-        explicit SubResource(SubResource&& other) noexcept;
-        explicit SubResource(const SubResource& other) noexcept;
         explicit SubResource(Data::Bytes&& data, const Index& index = Index(), BytesRangeOpt data_range = {}) noexcept;
         SubResource(Data::ConstRawPtr p_data, Data::Size size, const Index& index = Index(), BytesRangeOpt data_range = {}) noexcept;
         ~SubResource() = default;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Resource.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Resource.h
@@ -46,40 +46,26 @@ class DescriptorHeap;
 
 struct Resource : virtual Object
 {
-    enum class Type : uint32_t
+    enum class Type
     {
-        Buffer = 0U,
+        Buffer,
         Texture,
         Sampler,
     };
 
-    struct Usage
+    enum class Usage : uint32_t
     {
-        using Mask = uint32_t;
-        enum Value : Mask
-        {
-            Unknown      = 0U,
-            // Primary usages
-            ShaderRead   = 1U << 0U,
-            ShaderWrite  = 1U << 1U,
-            RenderTarget = 1U << 2U,
-            ReadBack     = 1U << 3U,
-            // Secondary usages
-            Addressable  = 1U << 4U,
-            All          = ~0U,
-        };
-
-        using BaseValues = std::array<Value, 4>;
-        static constexpr const BaseValues primary_values{ ShaderRead, ShaderWrite, RenderTarget };
-
-        using Values = std::array<Value, 5>;
-        static constexpr const Values values{ ShaderRead, ShaderWrite, RenderTarget, ReadBack, Addressable };
-
-        static std::string ToString(Usage::Value usage);
-        static std::string ToString(Usage::Mask usage_mask);
-
-        Usage() = delete;
+        None         = 0U,
+        // Primary usages
+        ShaderRead   = 1U << 0U,
+        ShaderWrite  = 1U << 1U,
+        RenderTarget = 1U << 2U,
+        ReadBack     = 1U << 3U,
+        // Secondary usages
+        Addressable  = 1U << 4U,
     };
+
+    static constexpr Usage s_secondary_usage_mask = Usage::Addressable;
 
     struct Descriptor
     {
@@ -89,7 +75,7 @@ struct Resource : virtual Object
         Descriptor(DescriptorHeap& in_heap, Data::Index in_index);
     };
 
-    using DescriptorByUsage = std::map<Usage::Value, Descriptor>;
+    using DescriptorByUsage = std::map<Usage, Descriptor>;
     
     class Location
     {
@@ -202,9 +188,6 @@ struct Resource : virtual Object
 
     using SubResources = std::vector<SubResource>;
 
-    // Auxiliary functions
-    static std::string GetTypeName(Type type);
-
     // Resource interface
     virtual void                      SetData(const SubResources& sub_resources) = 0;
     virtual SubResource               GetData(const SubResource::Index& sub_resource_index = SubResource::Index(), const std::optional<BytesRange>& data_range = {}) = 0;
@@ -212,9 +195,9 @@ struct Resource : virtual Object
     virtual Data::Size                GetSubResourceDataSize(const SubResource::Index& sub_resource_index = SubResource::Index()) const = 0;
     virtual const SubResource::Count& GetSubresourceCount() const noexcept = 0;
     virtual Type                      GetResourceType() const noexcept = 0;
-    virtual Usage::Mask               GetUsageMask() const noexcept = 0;
+    virtual Usage                     GetUsage() const noexcept = 0;
     virtual const DescriptorByUsage&  GetDescriptorByUsage() const noexcept = 0;
-    virtual const Descriptor&         GetDescriptor(Usage::Value usage) const = 0;
+    virtual const Descriptor&         GetDescriptor(Usage usage) const = 0;
     virtual Context&                  GetContext() noexcept = 0;
 };
 

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Shader.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Shader.h
@@ -41,12 +41,10 @@ struct Context;
 
 struct Shader
 {
-    enum class Type : uint32_t
+    enum class Type
     {
-        Vertex = 0,
+        Vertex,
         Pixel,
-        
-        Count,
         All
     };
     
@@ -85,7 +83,6 @@ struct Shader
     static Ptr<Shader> CreatePixel(Context& context, const Settings& settings)  { return Create(Type::Pixel, context, settings); }
 
     // Auxiliary functions
-    static std::string GetTypeName(Type shader_type);
     static std::string ConvertMacroDefinitionsToString(const MacroDefinitions& macro_definitions, const std::string& splitter = ", ") noexcept;
 
     // Shader interface

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Texture.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Texture.h
@@ -57,16 +57,16 @@ struct Texture : virtual Resource
     {
         Type           type           = Type::Texture;
         DimensionType  dimension_type = DimensionType::Tex2D;
-        Usage::Mask    usage_mask     = Usage::Value::Unknown;
+        Usage          usage_mask     = Usage::None;
         PixelFormat    pixel_format   = PixelFormat::Unknown;
         Dimensions     dimensions     = Dimensions();
         uint32_t       array_length   = 1U;
         bool           mipmapped      = false;
 
-        static Settings Image(const Dimensions& dimensions, uint32_t array_length, PixelFormat pixel_format, bool mipmapped, Usage::Mask usage);
-        static Settings Cube(uint32_t dimension_size, uint32_t array_length, PixelFormat pixel_format, bool mipmapped, Usage::Mask usage);
+        static Settings Image(const Dimensions& dimensions, uint32_t array_length, PixelFormat pixel_format, bool mipmapped, Usage usage);
+        static Settings Cube(uint32_t dimension_size, uint32_t array_length, PixelFormat pixel_format, bool mipmapped, Usage usage);
         static Settings FrameBuffer(const Dimensions& dimensions, PixelFormat pixel_format);
-        static Settings DepthStencilBuffer(const Dimensions& dimensions, PixelFormat pixel_format, Usage::Mask usage_mask = Usage::RenderTarget);
+        static Settings DepthStencilBuffer(const Dimensions& dimensions, PixelFormat pixel_format, Usage usage_mask = Usage::RenderTarget);
     };
 
     // Create Texture instance

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/BufferBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/BufferBase.cpp
@@ -28,6 +28,8 @@ Base implementation of the buffer interface.
 #include <Methane/Checks.hpp>
 #include <Methane/Instrumentation.h>
 
+#include <magic_enum.hpp>
+
 namespace Methane::Graphics
 {
 
@@ -53,19 +55,6 @@ uint32_t BufferBase::GetFormattedItemsCount() const noexcept
     return m_settings.item_stride_size > 0U ? GetDataSize(Data::MemoryState::Initialized) / m_settings.item_stride_size : 0U;
 }
 
-std::string Buffer::GetBufferTypeName(Type type)
-{
-    META_FUNCTION_TASK();
-    switch (type)
-    {
-    case Type::Data:     return "Data";
-    case Type::Index:    return "Index";
-    case Type::Vertex:   return "Vertex";
-    case Type::Constant: return "Constant";
-    default:             META_UNEXPECTED_ENUM_ARG_RETURN(type, "Unknown");
-    }
-}
-
 BufferSetBase::BufferSetBase(Buffer::Type buffers_type, const Refs<Buffer>& buffer_refs)
     : m_buffers_type(buffers_type)
     , m_refs(buffer_refs)
@@ -77,10 +66,8 @@ BufferSetBase::BufferSetBase(Buffer::Type buffers_type, const Refs<Buffer>& buff
     m_raw_ptrs.reserve(m_refs.size());
     for(const Ref<Buffer>& buffer_ref : m_refs)
     {
-        if (buffer_ref.get().GetSettings().type != m_buffers_type)
-        {
-            std::invalid_argument("All buffers must be of the same type \"" + Buffer::GetBufferTypeName(m_buffers_type) + "\"");
-        }
+        META_CHECK_ARG_EQUAL_DESCR(buffer_ref.get().GetSettings().type, m_buffers_type,
+                                   "All buffers must be of the same type '{}'", magic_enum::enum_name(m_buffers_type));
         auto& buffer_base = static_cast<BufferBase&>(buffer_ref.get());
         m_ptrs.emplace_back(buffer_base.GetBufferPtr());
         m_raw_ptrs.emplace_back(std::addressof(buffer_base));

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/BufferBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/BufferBase.h
@@ -44,8 +44,7 @@ public:
     const Settings& GetSettings() const noexcept final       { return m_settings; }
     uint32_t GetFormattedItemsCount() const noexcept final;
 
-    Ptr<BufferBase> GetBufferPtr()                              { return std::static_pointer_cast<BufferBase>(GetBasePtr()); }
-    std::string GetBufferTypeName() const noexcept              { return Buffer::GetBufferTypeName(m_settings.type); }
+    Ptr<BufferBase> GetBufferPtr()                           { return std::static_pointer_cast<BufferBase>(GetBasePtr()); }
 
 private:
     Settings    m_settings;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.cpp
@@ -164,7 +164,7 @@ void CommandListBase::Reset(DebugGroup* p_debug_group)
     }
 }
 
-void CommandListBase::SetProgramBindings(ProgramBindings& program_bindings, ProgramBindings::ApplyBehavior::Mask apply_behavior)
+void CommandListBase::SetProgramBindings(ProgramBindings& program_bindings, ProgramBindings::ApplyBehavior apply_behavior)
 {
     META_FUNCTION_TASK();
     if (m_command_state.program_bindings_ptr.get() == &program_bindings)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.h
@@ -84,7 +84,7 @@ public:
     void  PushDebugGroup(DebugGroup& debug_group) override;
     void  PopDebugGroup() override;
     void  Reset(DebugGroup* p_debug_group = nullptr) override;
-    void  SetProgramBindings(ProgramBindings& program_bindings, ProgramBindings::ApplyBehavior::Mask apply_behavior) override;
+    void  SetProgramBindings(ProgramBindings& program_bindings, ProgramBindings::ApplyBehavior apply_behavior) override;
     void  Commit() override;
     void  WaitUntilCompleted(uint32_t timeout_ms = 0U) override;
     Data::TimeRange GetGpuTimeRange(bool) const override { return { 0U, 0U }; }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.h
@@ -33,6 +33,7 @@ Base implementation of the command list interface.
 #include <Methane/TracyGpu.hpp>
 #include <Methane/Checks.hpp>
 
+#include <magic_enum.hpp>
 #include <stack>
 #include <mutex>
 #include <condition_variable>
@@ -128,17 +129,13 @@ protected:
     bool        IsExecuting(uint32_t frame_index) const     { return m_state == State::Executing && m_committed_frame_index == frame_index; }
     bool        IsExecuting() const                         { return IsExecuting(GetCurrentFrameIndex()); }
     uint32_t    GetCurrentFrameIndex() const;
-    std::string GetTypeName() const noexcept                { return GetTypeName(m_type); }
 
     inline void VerifyEncodingState() const
     {
         META_CHECK_ARG_EQUAL_DESCR(m_state, State::Encoding,
                                    "{} command list '{}' encoding is not possible in '{}' state",
-                                   GetTypeName(), GetName(), GetStateName(m_state));
+                                   magic_enum::enum_name(m_type), GetName(), magic_enum::enum_name(m_state));
     }
-
-    static std::string GetTypeName(Type type);
-    static std::string GetStateName(State state);
 
 private:
     using DebugGroupStack  = std::stack<Ptr<DebugGroupBase>>;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.cpp
@@ -73,7 +73,9 @@ Data::Index DescriptorHeap::AddResource(const ResourceBase& resource)
 
     if (!m_settings.deferred_allocation)
     {
-        META_CHECK_ARG_LESS_DESCR(m_resources.size(), m_settings.size + 1, "{} descriptor heap is full, no free space to add a resource", GetTypeName());
+        META_CHECK_ARG_LESS_DESCR(m_resources.size(), m_settings.size + 1,
+                                  "{} descriptor heap is full, no free space to add a resource",
+                                  magic_enum::flags::enum_name(m_settings.type));
     }
     else if (m_resources.size() >= m_settings.size)
     {
@@ -142,19 +144,6 @@ void DescriptorHeap::SetDeferredAllocation(bool deferred_allocation)
 {
     META_FUNCTION_TASK();
     m_settings.deferred_allocation = deferred_allocation;
-}
-
-std::string DescriptorHeap::GetTypeName(Type heap_type)
-{
-    META_FUNCTION_TASK();
-    switch (heap_type)
-    {
-        case Type::ShaderResources: return "Shader Resources";
-        case Type::Samplers:        return "Samplers";
-        case Type::RenderTargets:   return "Render Targets";
-        case Type::DepthStencil:    return "Depth Stencil";
-        default: META_UNEXPECTED_ENUM_ARG_RETURN(heap_type, "Undefined");
-    }
 }
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.h
@@ -89,7 +89,7 @@ public:
     };
 
     static Ptr<DescriptorHeap> Create(ContextBase& context, const Settings& settings);
-    virtual ~DescriptorHeap();
+    ~DescriptorHeap() override;
 
     // DescriptorHeap interface
     virtual Data::Index AddResource(const ResourceBase& resource);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.h
@@ -52,18 +52,18 @@ struct IDescriptorHeapCallback
 class DescriptorHeap : public Data::Emitter<IDescriptorHeapCallback>
 {
 public:
-    enum class Type
+    enum class Type : uint32_t
     {
         // Shader visible heap types
-        ShaderResources,
+        ShaderResources = 0U,
         Samplers,
 
         // Other heap types
         RenderTargets,
         DepthStencil,
 
-        Count,
-        Undefined,
+        // Always keep at the end
+        Undefined
     };
 
     struct Settings

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.h
@@ -52,10 +52,10 @@ struct IDescriptorHeapCallback
 class DescriptorHeap : public Data::Emitter<IDescriptorHeapCallback>
 {
 public:
-    enum class Type : uint32_t
+    enum class Type
     {
         // Shader visible heap types
-        ShaderResources = 0,
+        ShaderResources,
         Samplers,
 
         // Other heap types
@@ -105,12 +105,10 @@ public:
     const Settings&     GetSettings() const                             { return m_settings; }
     Data::Size          GetDeferredSize() const                         { return m_deferred_size; }
     Data::Size          GetAllocatedSize() const                        { return m_allocated_size; }
-    std::string         GetTypeName() const                             { return GetTypeName(m_settings.type); }
     const ResourceBase* GetResource(uint32_t descriptor_index) const    { return m_resources[descriptor_index]; }
     bool                IsShaderVisible() const                         { return m_settings.shader_visible && IsShaderVisibleHeapType(m_settings.type); }
 
     static bool         IsShaderVisibleHeapType(Type heap_type)         { return heap_type == Type::ShaderResources || heap_type == Type::Samplers; }
-    static std::string  GetTypeName(Type heap_type);
 
 protected:
     DescriptorHeap(ContextBase& context, const Settings& settings);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DeviceBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DeviceBase.cpp
@@ -31,39 +31,7 @@ Base implementation of the device interface.
 namespace Methane::Graphics
 {
 
-std::string Device::Feature::ToString(Value feature)
-{
-    META_FUNCTION_TASK();
-    switch(feature)
-    {
-    case Value::Unknown:                    return "Unknown";
-    case Value::All:                        return "All";
-    case Value::BasicRendering:             return "Basic Rendering";
-    case Value::TextureAndSamplerArrays:    return "Texture and Sampler Arrays";
-    default:                                META_UNEXPECTED_ENUM_ARG_RETURN(feature, "");
-    }
-}
-
-std::string Device::Feature::ToString(Mask features)
-{
-    META_FUNCTION_TASK();
-    std::stringstream ss;
-    bool is_first_feature = true;
-    for(Value value : values)
-    {
-        if (!(features & value))
-            continue;
-        
-        if (!is_first_feature)
-            ss << ", ";
-        
-        ss << ToString(value);
-        is_first_feature = false;
-    }
-    return ss.str();
-}
-
-DeviceBase::DeviceBase(const std::string& adapter_name, bool is_software_adapter, Feature::Mask supported_features)
+DeviceBase::DeviceBase(const std::string& adapter_name, bool is_software_adapter, Features supported_features)
     : m_adapter_name(adapter_name)
     , m_is_software_adapter(is_software_adapter)
     , m_supported_features(supported_features)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DeviceBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DeviceBase.h
@@ -37,12 +37,12 @@ class DeviceBase
     , public Data::Emitter<IDeviceCallback>
 {
 public:
-    DeviceBase(const std::string& adapter_name, bool is_software_adapter, Feature::Mask supported_features);
+    DeviceBase(const std::string& adapter_name, bool is_software_adapter, Features supported_features);
 
     // Device interface
     const std::string&  GetAdapterName() const noexcept override                               { return m_adapter_name; }
     bool                IsSoftwareAdapter() const noexcept override                            { return m_is_software_adapter; }
-    Feature::Mask       GetSupportedFeatures() const noexcept override                         { return m_supported_features; }
+    Features            GetSupportedFeatures() const noexcept override                         { return m_supported_features; }
     std::string         ToString() const override;
 
     Ptr<DeviceBase>     GetDevicePtr() { return std::static_pointer_cast<DeviceBase>(GetBasePtr()); }
@@ -54,30 +54,30 @@ protected:
     void OnRemoved();
 
 private:
-    const std::string    m_adapter_name;
-    const bool           m_is_software_adapter;
-    const Feature::Mask  m_supported_features;
+    const std::string m_adapter_name;
+    const bool        m_is_software_adapter;
+    const Features    m_supported_features;
 };
 
 class SystemBase : public System
 {
 public:
     const Ptrs<Device>&   GetGpuDevices() const override            { return m_devices; }
-    Device::Feature::Mask GetGpuSupportedFeatures() const override  { return m_supported_features; }
+    Device::Features      GetGpuSupportedFeatures() const override  { return m_supported_features; }
     Ptr<Device>           GetNextGpuDevice(const Device& device) const override;
     Ptr<Device>           GetSoftwareGpuDevice() const override;
     std::string           ToString() const override;
 
 protected:
-    void SetGpuSupportedFeatures(Device::Feature::Mask supported_features) { m_supported_features = supported_features; }
+    void SetGpuSupportedFeatures(Device::Features supported_features) { m_supported_features = supported_features; }
     void ClearDevices() { m_devices.clear(); }
     void AddDevice(const Ptr<Device>& device_ptr) { m_devices.emplace_back(device_ptr); }
     void RequestRemoveDevice(Device& device) const;
     void RemoveDevice(Device& device);
 
 private:
-    Device::Feature::Mask m_supported_features = Device::Feature::Value::All;
-    Ptrs<Device>          m_devices;
+    Device::Features m_supported_features = Device::Features::All;
+    Ptrs<Device>     m_devices;
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/BufferDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/BufferDX.cpp
@@ -159,7 +159,7 @@ const std::vector<D3D12_VERTEX_BUFFER_VIEW>& BufferSetDX::GetNativeVertexBufferV
     META_FUNCTION_TASK();
     const Buffer::Type buffers_type = GetType();
     META_CHECK_ARG_EQUAL_DESCR(buffers_type, Buffer::Type::Vertex,
-                               "unable to get vertex buffer views from buffer of {} type", Buffer::GetBufferTypeName(buffers_type));
+                               "unable to get vertex buffer views from buffer of {} type", magic_enum::enum_name(buffers_type));
     return m_vertex_buffer_views;
 }
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/CommandListDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/CommandListDX.cpp
@@ -28,6 +28,7 @@ DirectX 12 command lists collection implementation
 
 #include <Methane/Instrumentation.h>
 
+#include <magic_enum.hpp>
 #include <nowide/convert.hpp>
 
 namespace Methane::Graphics

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/CommandListDX.hpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/CommandListDX.hpp
@@ -158,7 +158,7 @@ public:
         CommandListBase::Reset(p_debug_group);
     }
 
-    void SetProgramBindings(ProgramBindings& program_bindings, ProgramBindings::ApplyBehavior::Mask apply_behavior) final
+    void SetProgramBindings(ProgramBindings& program_bindings, ProgramBindings::ApplyBehavior apply_behavior) final
     {
         META_FUNCTION_TASK();
         CommandListBase::CommandState& command_state = CommandListBase::GetCommandState();

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/DeviceDX.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/DeviceDX.h
@@ -43,7 +43,7 @@ namespace wrl = Microsoft::WRL;
 class DeviceDX final : public DeviceBase
 {
 public:
-    static Device::Feature::Mask GetSupportedFeatures(const wrl::ComPtr<IDXGIAdapter>& cp_adapter, D3D_FEATURE_LEVEL feature_level);
+    static Device::Features GetSupportedFeatures(const wrl::ComPtr<IDXGIAdapter>& cp_adapter, D3D_FEATURE_LEVEL feature_level);
 
     DeviceDX(const wrl::ComPtr<IDXGIAdapter>& cp_adapter, D3D_FEATURE_LEVEL feature_level);
     DeviceDX(const DeviceDX& device) noexcept = default;
@@ -80,7 +80,7 @@ public:
 
     // System interface
     void  CheckForChanges() override;
-    const Ptrs<Device>& UpdateGpuDevices(Device::Feature::Mask supported_features) override;
+    const Ptrs<Device>& UpdateGpuDevices(Device::Features supported_features) override;
 
     const wrl::ComPtr<IDXGIFactory5>& GetNativeFactory() const noexcept { return m_cp_factory; }
     void ReportLiveObjects() const;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ProgramBindingsDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ProgramBindingsDX.cpp
@@ -215,8 +215,7 @@ void ProgramBindingsDX::Apply(ICommandListDX& command_list_dx, const ProgramBind
     META_FUNCTION_TASK();
     using namespace magic_enum::bitwise_operators;
 
-    const bool apply_constant_resource_bindings   = !magic_enum::flags::enum_contains(apply_behavior & ApplyBehavior::ConstantOnce) ||
-                                                    std::addressof(*this) != p_applied_program_bindings;
+    const bool apply_constant_resource_bindings   = apply_behavior != ApplyBehavior::ConstantOnce || !p_applied_program_bindings;
     ID3D12GraphicsCommandList& d3d12_command_list = command_list_dx.GetNativeCommandList();
 
     // Set resource transition barriers before applying resource bindings

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ProgramBindingsDX.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ProgramBindingsDX.h
@@ -103,9 +103,9 @@ public:
 
     // ProgramBindings interface
     void CompleteInitialization() override;
-    void Apply(CommandListBase& command_list, ApplyBehavior::Mask apply_behavior) const override;
+    void Apply(CommandListBase& command_list, ApplyBehavior apply_behavior) const override;
 
-    void Apply(ICommandListDX& command_list_dx, const ProgramBindingsBase* p_applied_program_bindings, ApplyBehavior::Mask apply_behavior) const;
+    void Apply(ICommandListDX& command_list_dx, const ProgramBindingsBase* p_applied_program_bindings, ApplyBehavior apply_behavior) const;
 
 private:
     struct RootParameterBinding

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderPassDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderPassDX.cpp
@@ -298,7 +298,8 @@ void RenderPassDX::ForEachAccessibleDescriptorHeap(FuncType do_action) const
     const Settings& settings = GetSettings();
     const RenderContextBase& context = GetRenderContext();
 
-    for (Access access : magic_enum::enum_values<Access>())
+    static constexpr auto s_access_values = magic_enum::enum_values<Access>();
+    for (Access access : s_access_values)
     {
         if (!magic_enum::flags::enum_contains(settings.shader_access_mask & access))
             continue;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderPassDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderPassDX.cpp
@@ -34,6 +34,7 @@ DirectX 12 implementation of the render pass interface.
 #include <Methane/Instrumentation.h>
 #include <Methane/Checks.hpp>
 
+#include <magic_enum.hpp>
 #include <d3dx12.h>
 
 namespace Methane::Graphics
@@ -161,7 +162,7 @@ RenderPassDX::DSClearInfo::DSClearInfo(const RenderPass::DepthAttachment& depth_
     }
 }
 
-static DescriptorHeap::Type GetDescriptorHeapTypeByAccess(RenderPass::Access::Value access)
+static DescriptorHeap::Type GetDescriptorHeapTypeByAccess(RenderPass::Access access)
 {
     META_FUNCTION_TASK();
     switch (access)
@@ -292,11 +293,14 @@ template<typename FuncType>
 void RenderPassDX::ForEachAccessibleDescriptorHeap(FuncType do_action) const
 {
     META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
+
     const Settings& settings = GetSettings();
     const RenderContextBase& context = GetRenderContext();
-    for (Access::Value access : Access::values)
+
+    for (Access access : magic_enum::enum_values<Access>())
     {
-        if (!(settings.shader_access_mask & access))
+        if (!magic_enum::flags::enum_contains(settings.shader_access_mask & access))
             continue;
 
         const DescriptorHeap::Type heap_type = GetDescriptorHeapTypeByAccess(access);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderStateDX.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderStateDX.h
@@ -65,7 +65,7 @@ public:
     void Reset(const Settings& settings) override;
 
     // RenderStateBase interface
-    void Apply(RenderCommandListBase& command_list, Group::Mask state_groups) override;
+    void Apply(RenderCommandListBase& command_list, Groups state_groups) override;
 
     // Object interface
     void SetName(const std::string& name) override;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ResourceDX.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ResourceDX.h
@@ -76,9 +76,9 @@ public:
     virtual ID3D12Resource*                     GetNativeResource() const noexcept = 0;
     virtual const wrl::ComPtr<ID3D12Resource>&  GetNativeResourceComPtr() const noexcept = 0;
     virtual D3D12_GPU_VIRTUAL_ADDRESS           GetNativeGpuAddress() const noexcept = 0;
-    virtual D3D12_CPU_DESCRIPTOR_HANDLE         GetNativeCpuDescriptorHandle(Usage::Value usage) const noexcept = 0;
+    virtual D3D12_CPU_DESCRIPTOR_HANDLE         GetNativeCpuDescriptorHandle(Usage usage) const noexcept = 0;
     virtual D3D12_CPU_DESCRIPTOR_HANDLE         GetNativeCpuDescriptorHandle(const Descriptor& desc) const noexcept = 0;
-    virtual D3D12_GPU_DESCRIPTOR_HANDLE         GetNativeGpuDescriptorHandle(Usage::Value usage) const noexcept = 0;
+    virtual D3D12_GPU_DESCRIPTOR_HANDLE         GetNativeGpuDescriptorHandle(Usage usage) const noexcept = 0;
     virtual D3D12_GPU_DESCRIPTOR_HANDLE         GetNativeGpuDescriptorHandle(const Descriptor& desc) const noexcept = 0;
     virtual DescriptorHeap::Types               GetDescriptorHeapTypes() const noexcept = 0;
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ResourceDX.hpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ResourceDX.hpp
@@ -76,9 +76,9 @@ public:
     ID3D12Resource*                     GetNativeResource() const noexcept final                                  { return m_cp_resource.Get(); }
     const wrl::ComPtr<ID3D12Resource>&  GetNativeResourceComPtr() const noexcept final                            { return m_cp_resource; }
     D3D12_GPU_VIRTUAL_ADDRESS           GetNativeGpuAddress() const noexcept final                                { return m_cp_resource ? m_cp_resource->GetGPUVirtualAddress() : 0; }
-    D3D12_CPU_DESCRIPTOR_HANDLE         GetNativeCpuDescriptorHandle(Usage::Value usage) const noexcept final     { return GetNativeCpuDescriptorHandle(GetDescriptorByUsage(usage)); }
+    D3D12_CPU_DESCRIPTOR_HANDLE         GetNativeCpuDescriptorHandle(Usage usage) const noexcept final     { return GetNativeCpuDescriptorHandle(GetDescriptorByUsage(usage)); }
     D3D12_CPU_DESCRIPTOR_HANDLE         GetNativeCpuDescriptorHandle(const Descriptor& desc) const noexcept final { return static_cast<const DescriptorHeapDX&>(desc.heap).GetNativeCpuDescriptorHandle(desc.index); }
-    D3D12_GPU_DESCRIPTOR_HANDLE         GetNativeGpuDescriptorHandle(Usage::Value usage) const noexcept final     { return GetNativeGpuDescriptorHandle(GetDescriptorByUsage(usage)); }
+    D3D12_GPU_DESCRIPTOR_HANDLE         GetNativeGpuDescriptorHandle(Usage usage) const noexcept final     { return GetNativeGpuDescriptorHandle(GetDescriptorByUsage(usage)); }
     D3D12_GPU_DESCRIPTOR_HANDLE         GetNativeGpuDescriptorHandle(const Descriptor& desc) const noexcept final { return static_cast<const DescriptorHeapDX&>(desc.heap).GetNativeGpuDescriptorHandle(desc.index); }
     DescriptorHeap::Types               GetDescriptorHeapTypes() const noexcept final                             { return GetUsedDescriptorHeapTypes(); }
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ShaderDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ShaderDX.cpp
@@ -37,6 +37,7 @@ DirectX 12 implementation of the shader interface.
 #include <d3dcompiler.h>
 
 #include <nowide/convert.hpp>
+#include <magic_enum.hpp>
 #include <sstream>
 
 namespace Methane::Graphics
@@ -238,7 +239,7 @@ ShaderBase::ArgumentBindings ShaderDX::GetArgumentBindings(const Program::Argume
 
 #ifdef METHANE_LOGGING_ENABLED
     std::stringstream log_ss;
-    log_ss << std::endl << GetTypeName() << " shader v." << shader_desc.Version << " with argument bindings:" << std::endl;
+    log_ss << std::endl << magic_enum::flags::enum_name(GetType()) << " shader v." << shader_desc.Version << " with argument bindings:" << std::endl;
 #endif
 
     for (UINT resource_index = 0; resource_index < shader_desc.BoundResources; ++resource_index)
@@ -308,7 +309,7 @@ std::vector<D3D12_INPUT_ELEMENT_DESC> ShaderDX::GetNativeProgramInputLayout(cons
 
 #ifdef METHANE_LOGGING_ENABLED
     std::stringstream log_ss;
-    log_ss << std::endl << GetTypeName() << " shader input parameters:" << std::endl;
+    log_ss << std::endl << magic_enum::flags::enum_name(GetType()) << " shader input parameters:" << std::endl;
 #endif
 
     std::vector<uint32_t> input_buffer_byte_offsets;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/TextureDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/TextureDX.cpp
@@ -167,9 +167,9 @@ DepthStencilBufferTextureDX::TextureDX(ContextBase& render_context, const Settin
 
     using namespace magic_enum::bitwise_operators;
     const Usage usage_mask = GetUsage();
-    for (Usage usage : magic_enum::enum_values<Usage>())
+    for (Usage usage : ResourceBase::GetPrimaryUsageValues())
     {
-        if (!magic_enum::flags::enum_contains(usage & usage_mask & ~s_secondary_usage_mask) || usage == Usage::None)
+        if (!magic_enum::flags::enum_contains(usage & usage_mask))
             continue;
 
         const Descriptor& desc = ResourceBase::GetDescriptorByUsage(usage);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/BufferMT.mm
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/BufferMT.mm
@@ -48,28 +48,28 @@ static MTLResourceOptions GetNativeResourceOptions(Buffer::StorageMode storage_m
 Ptr<Buffer> Buffer::CreateVertexBuffer(Context& context, Data::Size size, Data::Size stride)
 {
     META_FUNCTION_TASK();
-    const Buffer::Settings settings{ Buffer::Type::Vertex, Usage::Unknown, size, stride, PixelFormat::Unknown, Buffer::StorageMode::Private };
+    const Buffer::Settings settings{ Buffer::Type::Vertex, Usage::None, size, stride, PixelFormat::Unknown, Buffer::StorageMode::Private };
     return std::make_shared<BufferMT>(dynamic_cast<ContextBase&>(context), settings);
 }
 
 Ptr<Buffer> Buffer::CreateIndexBuffer(Context& context, Data::Size size, PixelFormat format)
 {
     META_FUNCTION_TASK();
-    const Buffer::Settings settings{ Buffer::Type::Index, Usage::Unknown, size, GetPixelSize(format), format, Buffer::StorageMode::Private };
+    const Buffer::Settings settings{ Buffer::Type::Index, Usage::None, size, GetPixelSize(format), format, Buffer::StorageMode::Private };
     return std::make_shared<BufferMT>(dynamic_cast<ContextBase&>(context), settings);
 }
 
 Ptr<Buffer> Buffer::CreateConstantBuffer(Context& context, Data::Size size, bool addressable, const DescriptorByUsage& descriptor_by_usage)
 {
     META_FUNCTION_TASK();
-    const Usage::Mask usage_mask = Usage::ShaderRead | (addressable ? Usage::Addressable : Usage::Unknown);
+    const Usage usage_mask = Usage::ShaderRead | (addressable ? Usage::Addressable : Usage::None);
     const Buffer::Settings settings{ Buffer::Type::Constant, usage_mask, size, 0U, PixelFormat::Unknown, Buffer::StorageMode::Private };
     return std::make_shared<BufferMT>(dynamic_cast<ContextBase&>(context), settings, descriptor_by_usage);
 }
 
 Ptr<Buffer> Buffer::CreateVolatileBuffer(Context& context, Data::Size size, bool addressable, const DescriptorByUsage& descriptor_by_usage)
 {
-    const Usage::Mask usage_mask = Usage::ShaderRead | (addressable ? Usage::Addressable : Usage::Unknown);
+    const Usage usage_mask = Usage::ShaderRead | (addressable ? Usage::Addressable : Usage::None);
     const Buffer::Settings settings{ Buffer::Type::Constant, usage_mask, size, 0U, PixelFormat::Unknown, Buffer::StorageMode::Managed };
     return std::make_shared<BufferMT>(dynamic_cast<ContextBase&>(context), settings, descriptor_by_usage);
 }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/BufferMT.mm
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/BufferMT.mm
@@ -32,6 +32,8 @@ Metal implementation of the buffer interface.
 #include <Methane/Instrumentation.h>
 #include <Methane/Checks.hpp>
 
+#include <magic_enum.hpp>
+
 namespace Methane::Graphics
 {
 
@@ -62,6 +64,7 @@ Ptr<Buffer> Buffer::CreateIndexBuffer(Context& context, Data::Size size, PixelFo
 Ptr<Buffer> Buffer::CreateConstantBuffer(Context& context, Data::Size size, bool addressable, const DescriptorByUsage& descriptor_by_usage)
 {
     META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
     const Usage usage_mask = Usage::ShaderRead | (addressable ? Usage::Addressable : Usage::None);
     const Buffer::Settings settings{ Buffer::Type::Constant, usage_mask, size, 0U, PixelFormat::Unknown, Buffer::StorageMode::Private };
     return std::make_shared<BufferMT>(dynamic_cast<ContextBase&>(context), settings, descriptor_by_usage);
@@ -69,6 +72,7 @@ Ptr<Buffer> Buffer::CreateConstantBuffer(Context& context, Data::Size size, bool
 
 Ptr<Buffer> Buffer::CreateVolatileBuffer(Context& context, Data::Size size, bool addressable, const DescriptorByUsage& descriptor_by_usage)
 {
+    using namespace magic_enum::bitwise_operators;
     const Usage usage_mask = Usage::ShaderRead | (addressable ? Usage::Addressable : Usage::None);
     const Buffer::Settings settings{ Buffer::Type::Constant, usage_mask, size, 0U, PixelFormat::Unknown, Buffer::StorageMode::Managed };
     return std::make_shared<BufferMT>(dynamic_cast<ContextBase&>(context), settings, descriptor_by_usage);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/DeviceMT.hh
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/DeviceMT.hh
@@ -33,7 +33,7 @@ namespace Methane::Graphics
 class DeviceMT final : public DeviceBase
 {
 public:
-    static Device::Feature::Mask GetSupportedFeatures(const id<MTLDevice>& mtl_device);
+    static Device::Features GetSupportedFeatures(const id<MTLDevice>& mtl_device);
     
     DeviceMT(const id<MTLDevice>& mtl_device);
     ~DeviceMT() override;
@@ -50,7 +50,7 @@ public:
     ~SystemMT() override;
     
     void                CheckForChanges() override {}
-    const Ptrs<Device>& UpdateGpuDevices(Device::Feature::Mask supported_features) override;
+    const Ptrs<Device>& UpdateGpuDevices(Device::Features supported_features) override;
     
 private:
     void OnDeviceNotification(id<MTLDevice> mtl_device, MTLDeviceNotificationName device_notification);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ProgramBindingsMT.hh
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ProgramBindingsMT.hh
@@ -65,7 +65,7 @@ public:
     ProgramBindingsMT(const ProgramBindingsMT& other_program_bindings, const ResourceLocationsByArgument& replace_resource_location_by_argument);
 
     // ProgramBindings interface
-    void Apply(CommandListBase& command_list, ApplyBehavior::Mask apply_behavior) const override;
+    void Apply(CommandListBase& command_list, ApplyBehavior apply_behavior) const override;
 
     // ProgramBindingsBase interface
     void CompleteInitialization() override { }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ProgramBindingsMT.mm
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ProgramBindingsMT.mm
@@ -234,7 +234,7 @@ ProgramBindingsMT::ProgramBindingsMT(const ProgramBindingsMT& other_program_bind
     META_FUNCTION_TASK();
 }
 
-void ProgramBindingsMT::Apply(CommandListBase& command_list, ApplyBehavior::Mask apply_behavior) const
+void ProgramBindingsMT::Apply(CommandListBase& command_list, ApplyBehavior apply_behavior) const
 {
     META_FUNCTION_TASK();
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/RenderCommandListMT.mm
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/RenderCommandListMT.mm
@@ -31,6 +31,8 @@ Metal implementation of the render command list interface.
 #include <Methane/Instrumentation.h>
 #include <Methane/Checks.hpp>
 
+#include <magic_enum.hpp>
+
 namespace Methane::Graphics
 {
 
@@ -106,10 +108,12 @@ void RenderCommandListMT::ResetWithState(const Ptr<RenderState>& render_state_pt
 void RenderCommandListMT::SetVertexBuffers(BufferSet& vertex_buffers)
 {
     META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
+
     RenderCommandListBase::SetVertexBuffers(vertex_buffers);
 
     DrawingState& drawing_state = GetDrawingState();
-    if (!(drawing_state.changes & DrawingState::Changes::VertexBuffers))
+    if (!magic_enum::flags::enum_contains(drawing_state.changes & DrawingState::Changes::VertexBuffers))
         return;
 
     const auto& mtl_cmd_encoder = GetNativeCommandEncoder();

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/RenderStateMT.hh
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/RenderStateMT.hh
@@ -62,7 +62,7 @@ public:
     void Reset(const Settings& settings) override;
 
     // RenderStateBase interface
-    void Apply(RenderCommandListBase& command_list, Group::Mask state_groups) override;
+    void Apply(RenderCommandListBase& command_list, Groups state_groups) override;
 
     // Object interface
     void SetName(const std::string& name) override;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/RenderStateMT.mm
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/RenderStateMT.mm
@@ -32,6 +32,8 @@ Metal implementation of the render state interface.
 #include <Methane/Instrumentation.h>
 #include <Methane/Checks.hpp>
 
+#include <magic_enum.hpp>
+
 namespace Methane::Graphics
 {
 
@@ -65,16 +67,18 @@ static MTLTriangleFillMode ConvertRasterizerFillModeToMetal(RenderState::Rasteri
 static MTLColorWriteMask ConvertRenderTargetWriteMaskToMetal(RenderState::Blending::ColorChannels rt_write_mask)
 {
     META_FUNCTION_TASK();
-    using ColorChannel = RenderState::Blending::ColorChannel;
+    using namespace magic_enum::bitwise_operators;
+
+    using ColorChannels = RenderState::Blending::ColorChannels;
 
     MTLColorWriteMask mtl_color_write_mask = 0U;
-    if (rt_write_mask & ColorChannel::Red)
+    if (magic_enum::flags::enum_contains(rt_write_mask & ColorChannels::Red))
         mtl_color_write_mask |= MTLColorWriteMaskRed;
-    if (rt_write_mask & ColorChannel::Green)
+    if (magic_enum::flags::enum_contains(rt_write_mask & ColorChannels::Green))
         mtl_color_write_mask |= MTLColorWriteMaskGreen;
-    if (rt_write_mask & ColorChannel::Blue)
+    if (magic_enum::flags::enum_contains(rt_write_mask & ColorChannels::Blue))
         mtl_color_write_mask |= MTLColorWriteMaskBlue;
-    if (rt_write_mask & ColorChannel::Alpha)
+    if (magic_enum::flags::enum_contains(rt_write_mask & ColorChannels::Alpha))
         mtl_color_write_mask |= MTLColorWriteMaskAlpha;
     return mtl_color_write_mask;
 };
@@ -358,27 +362,28 @@ void RenderStateMT::Reset(const Settings& settings)
 void RenderStateMT::Apply(RenderCommandListBase& command_list, Groups state_groups)
 {
     META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
 
     RenderCommandListMT& metal_command_list = static_cast<RenderCommandListMT&>(command_list);
     const id<MTLRenderCommandEncoder>& mtl_cmd_encoder = metal_command_list.GetNativeCommandEncoder();
     
-    if (state_groups & Groups::Program    ||
-        state_groups & Groups::Rasterizer ||
-        state_groups & Groups::Blending)
+    if (magic_enum::flags::enum_contains(state_groups & Groups::Program)    ||
+        magic_enum::flags::enum_contains(state_groups & Groups::Rasterizer) ||
+        magic_enum::flags::enum_contains(state_groups & Groups::Blending))
     {
         [mtl_cmd_encoder setRenderPipelineState: GetNativePipelineState()];
     }
-    if (state_groups & Groups::DepthStencil)
+    if (magic_enum::flags::enum_contains(state_groups & Groups::DepthStencil))
     {
         [mtl_cmd_encoder setDepthStencilState: GetNativeDepthStencilState()];
     }
-    if (state_groups & Groups::Rasterizer)
+    if (magic_enum::flags::enum_contains(state_groups & Groups::Rasterizer))
     {
         [mtl_cmd_encoder setTriangleFillMode: m_mtl_fill_mode];
         [mtl_cmd_encoder setFrontFacingWinding: m_mtl_front_face_winding];
         [mtl_cmd_encoder setCullMode: m_mtl_cull_mode];
     }
-    if (state_groups & Groups::BlendingColor)
+    if (magic_enum::flags::enum_contains(state_groups & Groups::BlendingColor))
     {
         const Settings& settings = GetSettings();
         [mtl_cmd_encoder setBlendColorRed:settings.blending_color.GetRf()

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/RenderStateMT.mm
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/RenderStateMT.mm
@@ -62,7 +62,7 @@ static MTLTriangleFillMode ConvertRasterizerFillModeToMetal(RenderState::Rasteri
     }
 }
     
-static MTLColorWriteMask ConvertRenderTargetWriteMaskToMetal(RenderState::Blending::ColorChannel::Mask rt_write_mask)
+static MTLColorWriteMask ConvertRenderTargetWriteMaskToMetal(RenderState::Blending::ColorChannels rt_write_mask)
 {
     META_FUNCTION_TASK();
     using ColorChannel = RenderState::Blending::ColorChannel;
@@ -355,30 +355,30 @@ void RenderStateMT::Reset(const Settings& settings)
     ResetNativeState();
 }
 
-void RenderStateMT::Apply(RenderCommandListBase& command_list, Group::Mask state_groups)
+void RenderStateMT::Apply(RenderCommandListBase& command_list, Groups state_groups)
 {
     META_FUNCTION_TASK();
 
     RenderCommandListMT& metal_command_list = static_cast<RenderCommandListMT&>(command_list);
     const id<MTLRenderCommandEncoder>& mtl_cmd_encoder = metal_command_list.GetNativeCommandEncoder();
     
-    if (state_groups & Group::Program    ||
-        state_groups & Group::Rasterizer ||
-        state_groups & Group::Blending)
+    if (state_groups & Groups::Program    ||
+        state_groups & Groups::Rasterizer ||
+        state_groups & Groups::Blending)
     {
         [mtl_cmd_encoder setRenderPipelineState: GetNativePipelineState()];
     }
-    if (state_groups & Group::DepthStencil)
+    if (state_groups & Groups::DepthStencil)
     {
         [mtl_cmd_encoder setDepthStencilState: GetNativeDepthStencilState()];
     }
-    if (state_groups & Group::Rasterizer)
+    if (state_groups & Groups::Rasterizer)
     {
         [mtl_cmd_encoder setTriangleFillMode: m_mtl_fill_mode];
         [mtl_cmd_encoder setFrontFacingWinding: m_mtl_front_face_winding];
         [mtl_cmd_encoder setCullMode: m_mtl_cull_mode];
     }
-    if (state_groups & Group::BlendingColor)
+    if (state_groups & Groups::BlendingColor)
     {
         const Settings& settings = GetSettings();
         [mtl_cmd_encoder setBlendColorRed:settings.blending_color.GetRf()

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ShaderMT.mm
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ShaderMT.mm
@@ -33,6 +33,7 @@ Metal implementation of the shader interface.
 #include <Methane/Instrumentation.h>
 #include <Methane/Checks.hpp>
 
+#include <magic_enum.hpp>
 #include <regex>
 
 namespace Methane::Graphics
@@ -120,7 +121,7 @@ ShaderBase::ArgumentBindings ShaderMT::GetArgumentBindings(const Program::Argume
         return argument_bindings;
     
 #ifndef NDEBUG
-    NSLog(@"%s shader '%s' arguments:", GetTypeName().c_str(), GetCompiledEntryFunctionName().c_str());
+    NSLog(@"%s shader '%s' arguments:", magic_enum::enum_name(GetType()).data(), GetCompiledEntryFunctionName().c_str());
 #endif
 
     for(MTLArgument* mtl_arg in m_mtl_arguments)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/TextureMT.mm
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/TextureMT.mm
@@ -30,6 +30,7 @@ Metal implementation of the texture interface.
 #include <Methane/Instrumentation.h>
 #include <Methane/Checks.hpp>
 
+#include <magic_enum.hpp>
 #include <algorithm>
 
 namespace Methane::Graphics
@@ -216,16 +217,18 @@ RenderContextMT& TextureMT::GetRenderContextMT()
 MTLTextureUsage TextureMT::GetNativeTextureUsage()
 {
     META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
+
     NSUInteger texture_usage = MTLTextureUsageUnknown;
     const Settings& settings = GetSettings();
     
-    if (settings.usage_mask & static_cast<uint32_t>(TextureBase::Usage::ShaderRead))
+    if (magic_enum::flags::enum_contains(settings.usage_mask & TextureBase::Usage::ShaderRead))
         texture_usage |= MTLTextureUsageShaderRead;
     
-    if (settings.usage_mask & static_cast<uint32_t>(TextureBase::Usage::ShaderWrite))
+    if (magic_enum::flags::enum_contains(settings.usage_mask & TextureBase::Usage::ShaderWrite))
         texture_usage |= MTLTextureUsageShaderWrite;
     
-    if (settings.usage_mask & static_cast<uint32_t>(TextureBase::Usage::RenderTarget))
+    if (magic_enum::flags::enum_contains(settings.usage_mask & TextureBase::Usage::RenderTarget))
         texture_usage |= MTLTextureUsageRenderTarget;
 
     return texture_usage;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.cpp
@@ -28,6 +28,8 @@ Base implementation of the program interface.
 #include <Methane/Instrumentation.h>
 #include <Methane/Platform/Utils.h>
 
+#include <magic_enum.hpp>
+
 namespace Methane::Graphics
 {
 
@@ -51,17 +53,17 @@ bool Program::Argument::operator==(const Argument& other) const noexcept
 Program::Argument::operator std::string() const noexcept
 {
     META_FUNCTION_TASK();
-    return fmt::format("{} {}", Shader::GetTypeName(shader_type), name);
+    return fmt::format("{} {}", magic_enum::flags::enum_name(shader_type), name);
 }
 
-Program::ArgumentDesc::ArgumentDesc(Shader::Type shader_type, const std::string& argument_name, Modifiers::Mask modifiers) noexcept
+Program::ArgumentDesc::ArgumentDesc(Shader::Type shader_type, const std::string& argument_name, Modifiers modifiers) noexcept
     : Argument(shader_type, argument_name)
     , modifiers(modifiers)
 {
     META_FUNCTION_TASK();
 }
 
-Program::ArgumentDesc::ArgumentDesc(const Argument& argument, Modifiers::Mask modifiers) noexcept
+Program::ArgumentDesc::ArgumentDesc(const Argument& argument, Modifiers modifiers) noexcept
     : Argument(argument)
     , modifiers(modifiers)
 {
@@ -82,7 +84,7 @@ Program::ArgumentDescriptions::const_iterator Program::FindArgumentDescription(c
 
 Program::Argument::NotFoundException::NotFoundException(const Program& program, const Argument& argument)
     : std::invalid_argument(fmt::format("Program '{}' does not have argument '{}' of {} shader.",
-                                        program.GetName(), argument.name, Shader::GetTypeName(argument.shader_type)))
+                                        program.GetName(), argument.name, magic_enum::flags::enum_name(argument.shader_type)))
     , m_program(program)
     , m_argument_ptr(std::make_unique<Program::Argument>(argument))
 {
@@ -213,7 +215,7 @@ Shader& ProgramBase::GetShaderRef(Shader::Type shader_type)
 {
     META_FUNCTION_TASK();
     const Ptr<Shader>& shader_ptr = GetShader(shader_type);
-    META_CHECK_ARG_DESCR(shader_type, shader_ptr, "{} shader was not found in program '{}'", Shader::GetTypeName(shader_type), GetName());
+    META_CHECK_ARG_DESCR(shader_type, shader_ptr, "{} shader was not found in program '{}'", magic_enum::flags::enum_name(shader_type), GetName());
     return *shader_ptr;
 }
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.h
@@ -29,6 +29,7 @@ Base implementation of the program interface.
 #include "ShaderBase.h"
 #include "DescriptorHeap.h"
 
+#include <magic_enum.hpp>
 #include <memory>
 #include <array>
 #include <optional>
@@ -69,7 +70,7 @@ protected:
     Shader& GetShaderRef(Shader::Type shader_type);
     uint32_t GetInputBufferIndexByArgumentSemantic(const std::string& argument_semantic) const;
 
-    using ShadersByType = std::array<Ptr<Shader>, static_cast<size_t>(Shader::Type::Count)>;
+    using ShadersByType = std::array<Ptr<Shader>, magic_enum::enum_count<Shader::Type>() - 1>;
     static ShadersByType CreateShadersByType(const Ptrs<Shader>& shaders);
 
 private:

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBindingsBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBindingsBase.cpp
@@ -258,7 +258,7 @@ void ProgramBindingsBase::ReserveDescriptorHeapRanges()
         const DescriptorHeap::Type heap_type = descriptor_heap_type_and_count.first;
         const DescriptorsCount&  descriptors = descriptor_heap_type_and_count.second;
 
-        std::optional<DescriptorHeap::Reservation>& descriptor_heap_reservation_opt = m_descriptor_heap_reservations_by_type[static_cast<uint32_t>(heap_type)];
+        std::optional<DescriptorHeap::Reservation>& descriptor_heap_reservation_opt = m_descriptor_heap_reservations_by_type[magic_enum::enum_integer(heap_type)];
         if (!descriptor_heap_reservation_opt)
         {
             descriptor_heap_reservation_opt.emplace(
@@ -345,7 +345,7 @@ const std::optional<DescriptorHeap::Reservation>& ProgramBindingsBase::GetDescri
 {
     META_FUNCTION_TASK();
     META_CHECK_ARG_NOT_EQUAL(heap_type, DescriptorHeap::Type::Undefined);
-    return m_descriptor_heap_reservations_by_type[static_cast<uint32_t>(heap_type)];
+    return m_descriptor_heap_reservations_by_type[magic_enum::enum_integer(heap_type)];
 }
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBindingsBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBindingsBase.h
@@ -89,7 +89,7 @@ public:
 
     // ProgramBindingsBase interface
     virtual void CompleteInitialization() = 0;
-    virtual void Apply(CommandListBase& command_list, ApplyBehavior::Mask apply_behavior = ApplyBehavior::AllIncremental) const = 0;
+    virtual void Apply(CommandListBase& command_list, ApplyBehavior apply_behavior = ApplyBehavior::AllIncremental) const = 0;
 
     Program::Arguments GetUnboundArguments() const;
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBindingsBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBindingsBase.h
@@ -30,6 +30,7 @@ Base implementation of the program bindings interface.
 #include "CommandListBase.h"
 #include "ObjectBase.h"
 
+#include <magic_enum.hpp>
 #include <optional>
 
 namespace Methane::Graphics
@@ -105,8 +106,7 @@ protected:
     const std::optional<DescriptorHeap::Reservation>& GetDescriptorHeapReservationByType(DescriptorHeap::Type heap_type) const;
 
 private:
-    using DescriptorHeapReservationByType = std::array<std::optional<DescriptorHeap::Reservation>,
-                                                       static_cast<uint32_t>(DescriptorHeap::Type::Count)>;
+    using DescriptorHeapReservationByType = std::array<std::optional<DescriptorHeap::Reservation>, magic_enum::enum_count<DescriptorHeap::Type>() - 1>;
 
     const Ptr<Program>              m_program_ptr;
     Program::Arguments              m_arguments;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/QueryBuffer.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/QueryBuffer.cpp
@@ -30,6 +30,8 @@ GPU data query buffer base implementation.
 #include <Methane/Instrumentation.h>
 #include <Methane/Checks.hpp>
 
+#include <magic_enum.hpp>
+
 namespace Methane::Graphics
 {
 
@@ -63,7 +65,7 @@ void QueryBuffer::Query::End()
     const QueryBuffer::Type query_buffer_type = GetQueryBuffer().GetType();
     META_UNUSED(query_buffer_type);
     META_CHECK_ARG_DESCR(m_state, query_buffer_type == QueryBuffer::Type::Timestamp || m_state == State::Begun,
-                         "can not end {} query that was not begun", GetTypeName(query_buffer_type));
+                         "can not end {} query that was not begun", magic_enum::enum_name(query_buffer_type));
     m_state = State::Ended;
 }
 
@@ -104,16 +106,6 @@ QueryBuffer::CreateQueryArgs QueryBuffer::GetCreateQueryArguments()
     META_CHECK_ARG_DESCR(data_range, !data_range.IsEmpty(), "there is no space available for new query");
 
     return { index_range.GetStart(), data_range };
-}
-
-std::string QueryBuffer::GetTypeName(Type type)
-{
-    META_FUNCTION_TASK();
-    switch(type)
-    {
-    case Type::Timestamp: return "Timestamp";
-    default: META_UNEXPECTED_ENUM_ARG_RETURN(type, "Unknown");
-    }
 }
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/QueryBuffer.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/QueryBuffer.h
@@ -97,8 +97,6 @@ public:
     CommandQueueBase& GetCommandQueueBase() noexcept { return m_command_queue; }
     Context&          GetContext() noexcept          { return m_context; }
 
-    static std::string GetTypeName(Type type);
-
 protected:
     QueryBuffer(CommandQueueBase& command_queue, Type type,
                 Data::Size max_query_count, Data::Size buffer_size, Data::Size query_size);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.cpp
@@ -121,7 +121,7 @@ void RenderCommandListBase::SetVertexBuffers(BufferSet& vertex_buffers)
     {
         META_CHECK_ARG_NAME_DESCR("vertex_buffers", vertex_buffers.GetType() == Buffer::Type::Vertex,
                                   "can not set buffers of '{}' type where 'Vertex' buffers are required",
-                                  Buffer::GetBufferTypeName(vertex_buffers.GetType()));
+                                  magic_enum::enum_name(vertex_buffers.GetType()));
     }
 
     DrawingState&  drawing_state = GetDrawingState();
@@ -146,7 +146,7 @@ void RenderCommandListBase::DrawIndexed(Primitive primitive_type, Buffer& index_
     {
         META_CHECK_ARG_NAME_DESCR("index_buffer", index_buffer.GetSettings().type == Buffer::Type::Index,
                                   "can not draw with index buffer of type '{}' when 'Index' buffer is required",
-                                  static_cast<const BufferBase&>(index_buffer).GetBufferTypeName());
+                                  magic_enum::enum_name(index_buffer.GetSettings().type));
 
         const uint32_t formatted_items_count = index_buffer.GetFormattedItemsCount();
         META_CHECK_ARG_NOT_ZERO_DESCR(formatted_items_count, "can not draw with index buffer which contains no formatted vertices");

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.cpp
@@ -32,6 +32,8 @@ Base implementation of the render command list interface.
 
 #include <Methane/Instrumentation.h>
 
+#include <magic_enum.hpp>
+
 namespace Methane::Graphics
 {
 
@@ -65,14 +67,15 @@ void RenderCommandListBase::ResetWithState(const Ptr<RenderState>& render_state_
     }
 }
 
-void RenderCommandListBase::SetRenderState(RenderState& render_state, RenderState::Group::Mask state_groups)
+void RenderCommandListBase::SetRenderState(RenderState& render_state, RenderState::Groups state_groups)
 {
     META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
 
     VerifyEncodingState();
 
     const bool         render_state_changed = m_drawing_state.render_state_ptr.get() != std::addressof(render_state);
-    RenderState::Group::Mask changed_states = m_drawing_state.render_state_ptr ? RenderState::Group::None : RenderState::Group::All;
+    RenderState::Groups changed_states = m_drawing_state.render_state_ptr ? RenderState::Groups::None : RenderState::Groups::All;
     if (m_drawing_state.render_state_ptr && render_state_changed)
     {
         changed_states = RenderState::Settings::Compare(render_state.GetSettings(),
@@ -125,6 +128,7 @@ void RenderCommandListBase::SetVertexBuffers(BufferSet& vertex_buffers)
     if (drawing_state.vertex_buffer_set_ptr.get() == std::addressof(vertex_buffers))
         return;
 
+    using namespace magic_enum::bitwise_operators;
     Ptr<ObjectBase> vertex_buffer_set_object_ptr = static_cast<BufferSetBase&>(vertex_buffers).GetBasePtr();
     drawing_state.vertex_buffer_set_ptr = std::static_pointer_cast<BufferSetBase>(vertex_buffer_set_object_ptr);
     drawing_state.changes |= DrawingState::Changes::VertexBuffers;
@@ -183,14 +187,16 @@ void RenderCommandListBase::ResetCommandState()
     m_drawing_state.vertex_buffer_set_ptr.reset();
     m_drawing_state.index_buffer_ptr.reset();
     m_drawing_state.opt_primitive_type.reset();
-    m_drawing_state.p_view_state    = nullptr;
-    m_drawing_state.render_state_groups = RenderState::Group::None;
+    m_drawing_state.p_view_state = nullptr;
+    m_drawing_state.render_state_groups = RenderState::Groups::None;
     m_drawing_state.changes = DrawingState::Changes::None;
 }
 
 void RenderCommandListBase::UpdateDrawingState(Primitive primitive_type, Buffer* p_index_buffer)
 {
     META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
+
     DrawingState& drawing_state = GetDrawingState();
 
     if (p_index_buffer && (!drawing_state.index_buffer_ptr || drawing_state.index_buffer_ptr.get() != p_index_buffer))

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.h
@@ -45,19 +45,13 @@ class RenderCommandListBase
 public:
     struct DrawingState final
     {
-        struct Changes
+        enum class Changes : uint32_t
         {
-            using Mask = uint32_t;
-            enum Value : Mask
-            {
-                None          = 0U,
-                PrimitiveType = 1U << 0U,
-                IndexBuffer   = 1U << 1U,
-                VertexBuffers = 1U << 2U,
-                All           = ~0U,
-            };
-
-            Changes() = delete;
+            None          = 0U,
+            PrimitiveType = 1U << 0U,
+            IndexBuffer   = 1U << 1U,
+            VertexBuffers = 1U << 2U,
+            All           = ~0U
         };
 
         Ptrs<TextureBase>        render_pass_attachments_ptr;
@@ -66,8 +60,8 @@ public:
         Ptr<BufferBase>          index_buffer_ptr;
         std::optional<Primitive> opt_primitive_type;
         ViewStateBase*           p_view_state        = nullptr;
-        RenderState::Group::Mask render_state_groups = RenderState::Group::None;
-        Changes::Mask            changes             = Changes::None;
+        RenderState::Groups      render_state_groups = RenderState::Groups::None;
+        Changes                  changes             = Changes::None;
     };
 
     RenderCommandListBase(CommandQueueBase& command_queue, RenderPassBase& render_pass);
@@ -77,10 +71,10 @@ public:
 
     // RenderCommandList interface
     bool IsValidationEnabled() const noexcept override                      { return m_is_validation_enabled; }
-    void SetValidationEnabled(bool is_validation_enabled) override { m_is_validation_enabled = is_validation_enabled; }
+    void SetValidationEnabled(bool is_validation_enabled) override          { m_is_validation_enabled = is_validation_enabled; }
     RenderPass& GetRenderPass() const noexcept override                     { return *m_render_pass_ptr; }
     void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) override;
-    void SetRenderState(RenderState& render_state, RenderState::Group::Mask state_groups = RenderState::Group::All) override;
+    void SetRenderState(RenderState& render_state, RenderState::Groups state_groups = RenderState::Groups::All) override;
     void SetViewState(ViewState& view_state) override;
     void SetVertexBuffers(BufferSet& vertex_buffers) override;
     void DrawIndexed(Primitive primitive_type, Buffer& index_buffer,

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/RenderStateBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/RenderStateBase.cpp
@@ -26,6 +26,8 @@ Base implementation of the render state interface.
 #include <Methane/Checks.hpp>
 #include <Methane/Instrumentation.h>
 
+#include <magic_enum.hpp>
+
 namespace Methane::Graphics
 {
 
@@ -161,37 +163,38 @@ bool RenderState::Stencil::operator!=(const Stencil& other) const noexcept
     return !operator==(other);
 }
 
-RenderState::Group::Mask RenderState::Settings::Compare(const Settings& left, const Settings& right, Group::Mask compare_groups) noexcept
+RenderState::Groups RenderState::Settings::Compare(const Settings& left, const Settings& right, Groups compare_groups) noexcept
 {
     META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
     
-    Group::Mask changed_state_groups = Group::None;
+    Groups changed_state_groups = Groups::None;
     
-    if (compare_groups & Group::Program &&
+    if (magic_enum::flags::enum_contains(compare_groups & Groups::Program) &&
         left.program_ptr.get() != right.program_ptr.get())
     {
-        changed_state_groups |= Group::Program;
+        changed_state_groups |= Groups::Program;
     }
-    if (compare_groups & Group::Rasterizer &&
+    if (magic_enum::flags::enum_contains(compare_groups & Groups::Rasterizer) &&
         left.rasterizer != right.rasterizer)
     {
-        changed_state_groups |= Group::Rasterizer;
+        changed_state_groups |= Groups::Rasterizer;
     }
-    if (compare_groups & Group::Blending &&
+    if (magic_enum::flags::enum_contains(compare_groups & Groups::Blending) &&
         left.blending != right.blending)
     {
-        changed_state_groups |= Group::Blending;
+        changed_state_groups |= Groups::Blending;
     }
-    if (compare_groups & Group::BlendingColor &&
+    if (magic_enum::flags::enum_contains(compare_groups & Groups::BlendingColor) &&
         left.blending_color != right.blending_color)
     {
-        changed_state_groups |= Group::BlendingColor;
+        changed_state_groups |= Groups::BlendingColor;
     }
-    if (compare_groups & Group::DepthStencil && (
+    if (magic_enum::flags::enum_contains(compare_groups & Groups::DepthStencil) && (
         left.depth   != right.depth ||
         left.stencil != right.stencil))
     {
-        changed_state_groups |= Group::DepthStencil;
+        changed_state_groups |= Groups::DepthStencil;
     }
     
     return changed_state_groups;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/RenderStateBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/RenderStateBase.h
@@ -65,7 +65,7 @@ public:
     void Reset(const Settings& settings) override;
 
     // RenderStateBase interface
-    virtual void Apply(RenderCommandListBase& command_list, Group::Mask apply_groups) = 0;
+    virtual void Apply(RenderCommandListBase& command_list, Groups apply_groups) = 0;
 
     Ptr<RenderStateBase> GetRenderStatePtr()    { return std::static_pointer_cast<RenderStateBase>(GetBasePtr()); }
     RenderContextBase&   GetRenderContext()     { return m_context; }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
@@ -436,9 +436,9 @@ void ResourceBase::InitializeDefaultDescriptors()
 {
     META_FUNCTION_TASK();
     using namespace magic_enum::bitwise_operators;
-    for (Usage usage : magic_enum::enum_values<Usage>())
+    for (Usage usage : GetPrimaryUsageValues())
     {
-        if (!magic_enum::flags::enum_contains(usage & m_usage_mask & ~s_secondary_usage_mask) || usage == Usage::None)
+        if (!magic_enum::flags::enum_contains(usage & m_usage_mask))
             continue;
 
         auto descriptor_by_usage_it = m_descriptor_by_usage.find(usage);
@@ -680,6 +680,22 @@ std::string ResourceBase::GetStateName(State state)
     case State::Predication:             return "Predication";
     default:                             META_UNEXPECTED_ENUM_ARG_RETURN(state, "");
     }
+}
+
+const std::vector<Resource::Usage>& ResourceBase::GetPrimaryUsageValues() noexcept
+{
+    META_FUNCTION_TASK();
+    static std::vector<Resource::Usage> s_primary_usages;
+    if (!s_primary_usages.empty())
+        return s_primary_usages;
+
+    for (Usage usage : magic_enum::enum_values<Usage>())
+    {
+        using namespace magic_enum::bitwise_operators;
+        if (!magic_enum::flags::enum_contains(usage & s_secondary_usage_mask) && usage != Usage::None)
+            s_primary_usages.push_back(usage);
+    }
+    return s_primary_usages;
 }
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
@@ -130,17 +130,10 @@ ResourceBase::Barrier::operator std::string() const noexcept
 {
     META_FUNCTION_TASK();
     return fmt::format("Resource '{}' {} barrier from {} to {} state",
-                       m_id.GetResource().GetName(), GetTypeName(m_id.GetType()), GetStateName(m_state_change.GetStateBefore()), GetStateName(m_state_change.GetStateAfter()));
-}
-
-std::string ResourceBase::Barrier::GetTypeName(Type type)
-{
-    META_FUNCTION_TASK();
-    switch(type)
-    {
-    case Type::Transition: return "Transition";
-    default: META_UNEXPECTED_ENUM_ARG_RETURN(type, "");
-    }
+                       m_id.GetResource().GetName(),
+                       magic_enum::enum_name(m_id.GetType()),
+                       magic_enum::enum_name(m_state_change.GetStateBefore()),
+                       magic_enum::enum_name(m_state_change.GetStateAfter()));
 }
 
 Ptr<ResourceBase::Barriers> ResourceBase::Barriers::CreateTransition(const Refs<const Resource>& resources, State state_before, State state_after)
@@ -636,33 +629,6 @@ void ResourceBase::FillSubresourceSizes()
     {
         const SubResource::Index subresource_index(subresource_raw_index, m_sub_resource_count);
         m_sub_resource_sizes.emplace_back(CalculateSubResourceDataSize(subresource_index));
-    }
-}
-
-std::string ResourceBase::GetStateName(State state)
-{
-    META_FUNCTION_TASK();
-    switch(state)
-    {
-    case State::Common:                  return "Common";
-    case State::VertexAndConstantBuffer: return "VertexAndConstantBuffer";
-    case State::IndexBuffer:             return "IndexBuffer";
-    case State::RenderTarget:            return "RenderTarget";
-    case State::UnorderedAccess:         return "UnorderedAccess";
-    case State::DepthWrite:              return "DepthWrite";
-    case State::DepthRead:               return "DepthRead";
-    case State::NonPixelShaderResource:  return "NonPixelShaderResource";
-    case State::PixelShaderResource:     return "PixelShaderResource";
-    case State::StreamOut:               return "StreamOut";
-    case State::IndirectArgument:        return "IndirectArgument";
-    case State::CopyDest:                return "CopyDest";
-    case State::CopySource:              return "CopySource";
-    case State::ResolveDest:             return "ResolveDest";
-    case State::ResolveSource:           return "ResolveSource";
-    case State::GenericRead:             return "GenericRead";
-    case State::Present:                 return "Present";
-    case State::Predication:             return "Predication";
-    default:                             META_UNEXPECTED_ENUM_ARG_RETURN(state, "");
     }
 }
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
@@ -259,22 +259,6 @@ bool Resource::Location::operator==(const Location& other) const noexcept
            std::tie(other.m_resource_ptr, other.m_offset);
 }
 
-Resource::SubResource::SubResource(SubResource&& other) noexcept
-    : Data::Chunk(std::move(static_cast<Data::Chunk&&>(other)))
-    , m_index(other.m_index)
-    , m_data_range(std::move(other.m_data_range))
-{
-    META_FUNCTION_TASK();
-}
-
-Resource::SubResource::SubResource(const SubResource& other) noexcept
-    : Data::Chunk(other)
-    , m_index(other.m_index)
-    , m_data_range(other.m_data_range)
-{
-    META_FUNCTION_TASK();
-}
-
 Resource::SubResource::SubResource(Data::Bytes&& data, const Index& index, BytesRangeOpt data_range) noexcept
     : Data::Chunk(std::move(data))
     , m_index(index)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.h
@@ -191,6 +191,7 @@ public:
     bool    SetState(State state, Ptr<Barriers>& out_barriers);
 
     static std::string GetStateName(State state);
+    static const std::vector<Resource::Usage>& GetPrimaryUsageValues() noexcept;
 
 protected:
     ContextBase&         GetContextBase()                                       { return m_context; }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.h
@@ -128,8 +128,6 @@ public:
         bool operator!=(const Barrier& other) const noexcept;
         explicit operator std::string() const noexcept;
 
-        static std::string GetTypeName(Type type);
-
         const Id&          GetId() const noexcept          { return m_id; }
         const StateChange& GetStateChange() const noexcept { return m_state_change; }
 
@@ -190,7 +188,6 @@ public:
     State   GetState() const noexcept                                            { return m_state;  }
     bool    SetState(State state, Ptr<Barriers>& out_barriers);
 
-    static std::string GetStateName(State state);
     static const std::vector<Resource::Usage>& GetPrimaryUsageValues() noexcept;
 
 protected:

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.h
@@ -168,16 +168,16 @@ public:
         Map  m_barriers_map;
     };
 
-    ResourceBase(Type type, Usage::Mask usage_mask, ContextBase& context, const DescriptorByUsage& descriptor_by_usage);
+    ResourceBase(Type type, Usage usage_mask, ContextBase& context, const DescriptorByUsage& descriptor_by_usage);
     ResourceBase(const ResourceBase&) = delete;
     ResourceBase(ResourceBase&&) = delete;
     ~ResourceBase() override;
 
     // Resource interface
     Type                      GetResourceType() const noexcept final             { return m_type; }
-    Usage::Mask               GetUsageMask() const noexcept final                { return m_usage_mask; }
+    Usage                     GetUsage() const noexcept final                    { return m_usage_mask; }
     const DescriptorByUsage&  GetDescriptorByUsage() const noexcept final        { return m_descriptor_by_usage; }
-    const Descriptor&         GetDescriptor(Usage::Value usage) const final;
+    const Descriptor&         GetDescriptor(Usage usage) const final;
     void                      SetData(const SubResources& sub_resources) override;
     SubResource               GetData(const SubResource::Index& sub_resource_index = SubResource::Index(), const std::optional<BytesRange>& data_range = {}) override;
     const SubResource::Count& GetSubresourceCount() const noexcept final         { return m_sub_resource_count; }
@@ -185,8 +185,6 @@ public:
     Context&                  GetContext() noexcept final;
 
     void                      InitializeDefaultDescriptors();
-    std::string               GetUsageNames() const noexcept                     { return Usage::ToString(m_usage_mask); }
-    std::string               GetResourceTypeName() const noexcept               { return Resource::GetTypeName(m_type); }
     DescriptorHeap::Types     GetUsedDescriptorHeapTypes() const noexcept;
 
     State   GetState() const noexcept                                            { return m_state;  }
@@ -196,8 +194,8 @@ public:
 
 protected:
     ContextBase&         GetContextBase()                                       { return m_context; }
-    DescriptorHeap::Type GetDescriptorHeapTypeByUsage(Usage::Value usage) const;
-    const Descriptor&    GetDescriptorByUsage(Usage::Value usage) const;
+    DescriptorHeap::Type GetDescriptorHeapTypeByUsage(Usage usage) const;
+    const Descriptor&    GetDescriptorByUsage(Usage usage) const;
     Data::Size           GetInitializedDataSize() const noexcept                { return m_initialized_data_size; }
     void                 SetSubResourceCount(const SubResource::Count& sub_resource_count);
     void                 ValidateSubResource(const SubResource& sub_resource) const;
@@ -210,7 +208,7 @@ private:
     void FillSubresourceSizes();
 
     const Type         m_type;
-    const Usage::Mask  m_usage_mask;
+    const Usage        m_usage_mask;
     ContextBase&       m_context;
     DescriptorByUsage  m_descriptor_by_usage;
     State              m_state = State::Common;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceManager.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceManager.cpp
@@ -30,6 +30,7 @@ and deferred releasing of GPU resource.
 #include <Methane/Checks.hpp>
 
 #include <taskflow/taskflow.hpp>
+#include <magic_enum.hpp>
 
 namespace Methane::Graphics
 {
@@ -173,7 +174,7 @@ const Ptr<DescriptorHeap>& ResourceManager::GetDescriptorHeapPtr(DescriptorHeap:
     }
 
     Ptrs<DescriptorHeap>& desc_heaps = m_descriptor_heap_types[static_cast<size_t>(type)];
-    META_CHECK_ARG_LESS_DESCR(heap_index, desc_heaps.size(), "descriptor heap of type '{}' index is not valid", DescriptorHeap::GetTypeName(type));
+    META_CHECK_ARG_LESS_DESCR(heap_index, desc_heaps.size(), "descriptor heap of type '{}' index is not valid", magic_enum::flags::enum_name(type));
 
     return desc_heaps[heap_index];
 }
@@ -185,7 +186,7 @@ DescriptorHeap& ResourceManager::GetDescriptorHeap(DescriptorHeap::Type type, Da
                          "can not get reference to 'Undefined' descriptor heap");
 
     const Ptr<DescriptorHeap>& resource_heap_ptr = GetDescriptorHeapPtr(type, heap_index);
-    META_CHECK_ARG_NOT_NULL_DESCR(resource_heap_ptr, "descriptor heap of type '{}' at index {} does not exist", DescriptorHeap::GetTypeName(type), heap_index);
+    META_CHECK_ARG_NOT_NULL_DESCR(resource_heap_ptr, "descriptor heap of type '{}' at index {} does not exist", magic_enum::flags::enum_name(type), heap_index);
 
     return *resource_heap_ptr;
 }
@@ -218,7 +219,7 @@ DescriptorHeap& ResourceManager::GetDefaultShaderVisibleDescriptorHeap(Descripto
     META_FUNCTION_TASK();
 
     const Ptr<DescriptorHeap>& resource_heap_ptr = GetDefaultShaderVisibleDescriptorHeapPtr(type);
-    META_CHECK_ARG_NOT_NULL_DESCR(resource_heap_ptr, "There is no shader visible descriptor heap of type '{}'", DescriptorHeap::GetTypeName(type));
+    META_CHECK_ARG_NOT_NULL_DESCR(resource_heap_ptr, "There is no shader visible descriptor heap of type '{}'", magic_enum::flags::enum_name(type));
 
     return *resource_heap_ptr;
 }
@@ -256,7 +257,8 @@ void ResourceManager::ForEachDescriptorHeap(FuncType process_heap) const
             const DescriptorHeap::Type heap_type = desc_heap_ptr->GetSettings().type;
             META_CHECK_ARG_EQUAL_DESCR(heap_type, desc_heaps_type,
                                        "wrong type of {} descriptor heap was found in container assuming heaps of {} type",
-                                       DescriptorHeap::GetTypeName(heap_type), DescriptorHeap::GetTypeName(desc_heaps_type));
+                                       magic_enum::flags::enum_name(heap_type),
+                                       magic_enum::flags::enum_name(desc_heaps_type));
             process_heap(*desc_heap_ptr);
         }
         META_UNUSED(desc_heaps_type);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceManager.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceManager.cpp
@@ -38,7 +38,7 @@ namespace Methane::Graphics
 inline void AddDescriptorHeap(Ptrs<DescriptorHeap>& desc_heaps, ContextBase& context, bool deferred_heap_allocation,
                               const ResourceManager::Settings& settings, DescriptorHeap::Type heap_type, bool is_shader_visible)
 {
-    const auto heap_type_idx = static_cast<uint32_t>(heap_type);
+    const auto heap_type_idx = magic_enum::enum_integer(heap_type);
     const uint32_t heap_size = is_shader_visible ? settings.shader_visible_heap_sizes[heap_type_idx] : settings.default_heap_sizes[heap_type_idx];
     const DescriptorHeap::Settings heap_settings{ heap_type, heap_size, deferred_heap_allocation, is_shader_visible };
     desc_heaps.push_back(DescriptorHeap::Create(context, heap_settings));
@@ -55,10 +55,12 @@ void ResourceManager::Initialize(const Settings& settings)
     META_FUNCTION_TASK();
 
     m_deferred_heap_allocation = settings.deferred_heap_allocation;
-    for (uint32_t heap_type_idx = 0; heap_type_idx < static_cast<uint32_t>(DescriptorHeap::Type::Count); ++heap_type_idx)
+    for (const DescriptorHeap::Type heap_type : magic_enum::enum_values<DescriptorHeap::Type>())
     {
-        const auto            heap_type  = static_cast<DescriptorHeap::Type>(heap_type_idx);
-        Ptrs<DescriptorHeap>& desc_heaps = m_descriptor_heap_types[heap_type_idx];
+        if (heap_type == DescriptorHeap::Type::Undefined)
+            continue;
+
+        Ptrs<DescriptorHeap>& desc_heaps = m_descriptor_heap_types[magic_enum::enum_integer(heap_type)];
         desc_heaps.clear();
 
         // CPU only accessible descriptor heaps of all types are created for default resource creation
@@ -154,10 +156,10 @@ void ResourceManager::AddProgramBindings(ProgramBindings& program_bindings)
 uint32_t ResourceManager::CreateDescriptorHeap(const DescriptorHeap::Settings& settings)
 {
     META_FUNCTION_TASK();
-    META_CHECK_ARG_DESCR(settings.type, settings.type != DescriptorHeap::Type::Undefined && settings.type != DescriptorHeap::Type::Count,
+    META_CHECK_ARG_DESCR(settings.type, settings.type != DescriptorHeap::Type::Undefined,
                          "can not create 'Undefined' descriptor heap");
 
-    Ptrs<DescriptorHeap>& desc_heaps = m_descriptor_heap_types[static_cast<size_t>(settings.type)];
+    Ptrs<DescriptorHeap>& desc_heaps = m_descriptor_heap_types[magic_enum::enum_integer(settings.type)];
     desc_heaps.push_back(DescriptorHeap::Create(m_context, settings));
     return static_cast<uint32_t>(desc_heaps.size() - 1);
 }
@@ -166,14 +168,13 @@ const Ptr<DescriptorHeap>& ResourceManager::GetDescriptorHeapPtr(DescriptorHeap:
 {
     META_FUNCTION_TASK();
 
-    if (type == DescriptorHeap::Type::Undefined ||
-        type == DescriptorHeap::Type::Count)
+    if (type == DescriptorHeap::Type::Undefined)
     {
         static const Ptr<DescriptorHeap> s_empty_ptr;
         return s_empty_ptr;
     }
 
-    Ptrs<DescriptorHeap>& desc_heaps = m_descriptor_heap_types[static_cast<size_t>(type)];
+    Ptrs<DescriptorHeap>& desc_heaps = m_descriptor_heap_types[magic_enum::enum_integer(type)];
     META_CHECK_ARG_LESS_DESCR(heap_index, desc_heaps.size(), "descriptor heap of type '{}' index is not valid", magic_enum::flags::enum_name(type));
 
     return desc_heaps[heap_index];
@@ -182,7 +183,7 @@ const Ptr<DescriptorHeap>& ResourceManager::GetDescriptorHeapPtr(DescriptorHeap:
 DescriptorHeap& ResourceManager::GetDescriptorHeap(DescriptorHeap::Type type, Data::Index heap_index)
 {
     META_FUNCTION_TASK();
-    META_CHECK_ARG_DESCR(type, type != DescriptorHeap::Type::Undefined && type != DescriptorHeap::Type::Count,
+    META_CHECK_ARG_DESCR(type, type != DescriptorHeap::Type::Undefined,
                          "can not get reference to 'Undefined' descriptor heap");
 
     const Ptr<DescriptorHeap>& resource_heap_ptr = GetDescriptorHeapPtr(type, heap_index);
@@ -195,14 +196,13 @@ const Ptr<DescriptorHeap>&  ResourceManager::GetDefaultShaderVisibleDescriptorHe
 {
     META_FUNCTION_TASK();
 
-    if (type == DescriptorHeap::Type::Undefined ||
-        type == DescriptorHeap::Type::Count)
+    if (type == DescriptorHeap::Type::Undefined)
     {
         static const Ptr<DescriptorHeap> s_empty_ptr;
         return s_empty_ptr;
     }
 
-    const Ptrs<DescriptorHeap>& descriptor_heaps = m_descriptor_heap_types[static_cast<uint32_t>(type)];
+    const Ptrs<DescriptorHeap>& descriptor_heaps = m_descriptor_heap_types[magic_enum::enum_integer(type)];
     auto descriptor_heaps_it = std::find_if(descriptor_heaps.begin(), descriptor_heaps.end(),
         [](const Ptr<DescriptorHeap>& descriptor_heap_ptr)
         {
@@ -236,7 +236,7 @@ ResourceManager::DescriptorHeapSizeByType ResourceManager::GetDescriptorHeapSize
             return;
 
         const uint32_t heap_size = get_allocated_size ? descriptor_heap.GetAllocatedSize() : descriptor_heap.GetDeferredSize();
-        uint32_t& max_desc_heap_size = max_descriptor_heap_sizes[static_cast<size_t>(descriptor_heap.GetSettings().type)];
+        uint32_t& max_desc_heap_size = max_descriptor_heap_sizes[magic_enum::enum_integer(descriptor_heap.GetSettings().type)];
         max_desc_heap_size = std::max(max_desc_heap_size, heap_size);
     });
 
@@ -247,10 +247,12 @@ template<typename FuncType>
 void ResourceManager::ForEachDescriptorHeap(FuncType process_heap) const
 {
     META_FUNCTION_TASK();
-    for (uint32_t heap_type_idx = 0; heap_type_idx < static_cast<uint32_t>(DescriptorHeap::Type::Count); ++heap_type_idx)
+    for (const DescriptorHeap::Type desc_heaps_type : magic_enum::enum_values<DescriptorHeap::Type>())
     {
-        const auto desc_heaps_type = static_cast<DescriptorHeap::Type>(heap_type_idx);
-        const Ptrs<DescriptorHeap>& desc_heaps = m_descriptor_heap_types[heap_type_idx];
+        if (desc_heaps_type == DescriptorHeap::Type::Undefined)
+            continue;
+
+        const Ptrs<DescriptorHeap>& desc_heaps = m_descriptor_heap_types[magic_enum::enum_integer(desc_heaps_type)];
         for (const Ptr<DescriptorHeap>& desc_heap_ptr : desc_heaps)
         {
             META_CHECK_ARG_NOT_NULL(desc_heap_ptr);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceManager.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceManager.h
@@ -30,6 +30,7 @@ and deferred releasing of GPU resource.
 
 #include <Methane/Instrumentation.h>
 
+#include <magic_enum.hpp>
 #include <array>
 #include <mutex>
 
@@ -41,7 +42,7 @@ class ContextBase;
 class ResourceManager
 {
 public:
-    using DescriptorHeapSizeByType = std::array<uint32_t, static_cast<size_t>(DescriptorHeap::Type::Count)>;
+    using DescriptorHeapSizeByType = std::array<uint32_t, magic_enum::enum_count<DescriptorHeap::Type>() - 1>;
 
     struct Settings
     {
@@ -73,7 +74,7 @@ private:
     template<typename FuncType> // function void(DescriptorHeap& descriptor_heap)
     void ForEachDescriptorHeap(FuncType process_heap) const;
 
-    using DescriptorHeapTypes = std::array<Ptrs<DescriptorHeap>, static_cast<size_t>(DescriptorHeap::Type::Count)>;
+    using DescriptorHeapTypes = std::array<Ptrs<DescriptorHeap>, magic_enum::enum_count<DescriptorHeap::Type>() - 1>;
 
     bool                      m_deferred_heap_allocation = false;
     ContextBase&              m_context;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ShaderBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ShaderBase.cpp
@@ -30,18 +30,6 @@ Base implementation of the shader interface.
 namespace Methane::Graphics
 {
 
-std::string Shader::GetTypeName(Type shader_type)
-{
-    META_FUNCTION_TASK();
-    switch (shader_type)
-    {
-    case Type::Vertex:    return "Vertex";
-    case Type::Pixel:     return "Pixel";
-    case Type::All:       return "All";
-    default:              META_UNEXPECTED_ENUM_ARG_RETURN(shader_type, "Unknown");
-    }
-}
-
 std::string Shader::ConvertMacroDefinitionsToString(const MacroDefinitions& macro_definitions, const std::string& splitter) noexcept
 {
     META_FUNCTION_TASK();

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ShaderBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ShaderBase.h
@@ -52,7 +52,6 @@ public:
     virtual ArgumentBindings GetArgumentBindings(const Program::ArgumentDescriptions& argument_descriptions) const = 0;
 
     Ptr<ShaderBase> GetPtr()                { return shared_from_this(); }
-    std::string     GetTypeName() const     { return Shader::GetTypeName(m_type); }
 
 protected:
     ContextBase&        GetContext()        { return m_context; }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/TextureBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/TextureBase.cpp
@@ -32,7 +32,7 @@ Base implementation of the texture interface.
 namespace Methane::Graphics
 {
 
-Texture::Settings Texture::Settings::Image(const Dimensions& dimensions, uint32_t array_length, PixelFormat pixel_format, bool mipmapped, TextureBase::Usage::Mask usage)
+Texture::Settings Texture::Settings::Image(const Dimensions& dimensions, uint32_t array_length, PixelFormat pixel_format, bool mipmapped, TextureBase::Usage usage)
 {
     META_FUNCTION_TASK();
 
@@ -53,7 +53,7 @@ Texture::Settings Texture::Settings::Image(const Dimensions& dimensions, uint32_
     return settings;
 }
 
-Texture::Settings Texture::Settings::Cube(uint32_t dimension_size, uint32_t array_length, PixelFormat pixel_format, bool mipmapped, Usage::Mask usage)
+Texture::Settings Texture::Settings::Cube(uint32_t dimension_size, uint32_t array_length, PixelFormat pixel_format, bool mipmapped, Usage usage)
 {
     META_FUNCTION_TASK();
 
@@ -83,7 +83,7 @@ Texture::Settings Texture::Settings::FrameBuffer(const Dimensions& dimensions, P
     return settings;
 }
 
-Texture::Settings Texture::Settings::DepthStencilBuffer(const Dimensions& dimensions, PixelFormat pixel_format, Usage::Mask usage_mask)
+Texture::Settings Texture::Settings::DepthStencilBuffer(const Dimensions& dimensions, PixelFormat pixel_format, Usage usage_mask)
 {
     META_FUNCTION_TASK();
 
@@ -102,7 +102,7 @@ TextureBase::TextureBase(ContextBase& context, const Settings& settings, const D
     , m_settings(settings)
 {
     META_FUNCTION_TASK();
-    META_CHECK_ARG_NOT_EQUAL_DESCR(m_settings.usage_mask, TextureBase::Usage::Unknown, "can not create texture with 'Unknown' usage mask");
+    META_CHECK_ARG_NOT_EQUAL_DESCR(m_settings.usage_mask, TextureBase::Usage::None, "can not create texture with 'Unknown' usage mask");
     META_CHECK_ARG_NOT_EQUAL_DESCR(m_settings.pixel_format, PixelFormat::Unknown, "can not create texture with 'Unknown' pixel format");
     META_CHECK_ARG_NOT_NULL_DESCR(m_settings.array_length, "array length should be greater than zero");
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/BufferVK.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/BufferVK.cpp
@@ -35,28 +35,28 @@ namespace Methane::Graphics
 Ptr<Buffer> Buffer::CreateVertexBuffer(Context& context, Data::Size size, Data::Size stride)
 {
     META_FUNCTION_TASK();
-    const Buffer::Settings settings{ Buffer::Type::Vertex, Usage::Unknown, size, stride, PixelFormat::Unknown, Buffer::StorageMode::Private };
+    const Buffer::Settings settings{ Buffer::Type::Vertex, Usage::None, size, stride, PixelFormat::Unknown, Buffer::StorageMode::Private };
     return std::make_shared<BufferVK>(dynamic_cast<ContextBase&>(context), settings);
 }
 
 Ptr<Buffer> Buffer::CreateIndexBuffer(Context& context, Data::Size size, PixelFormat format)
 {
     META_FUNCTION_TASK();
-    const Buffer::Settings settings{ Buffer::Type::Index, Usage::Unknown, size, GetPixelSize(format), format, Buffer::StorageMode::Private };
+    const Buffer::Settings settings{ Buffer::Type::Index, Usage::None, size, GetPixelSize(format), format, Buffer::StorageMode::Private };
     return std::make_shared<BufferVK>(dynamic_cast<ContextBase&>(context), settings);
 }
 
 Ptr<Buffer> Buffer::CreateConstantBuffer(Context& context, Data::Size size, bool addressable, const DescriptorByUsage& descriptor_by_usage)
 {
     META_FUNCTION_TASK();
-    const Usage::Mask usage_mask = Usage::ShaderRead | (addressable ? Usage::Addressable : Usage::Unknown);
+    const Usage usage_mask = Usage::ShaderRead | (addressable ? Usage::Addressable : Usage::None);
     const Buffer::Settings settings{ Buffer::Type::Constant, usage_mask, size, 0U, PixelFormat::Unknown, Buffer::StorageMode::Private };
     return std::make_shared<BufferVK>(dynamic_cast<ContextBase&>(context), settings, descriptor_by_usage);
 }
 
 Ptr<Buffer> Buffer::CreateVolatileBuffer(Context& context, Data::Size size, bool addressable, const DescriptorByUsage& descriptor_by_usage)
 {
-    const Usage::Mask usage_mask = Usage::ShaderRead | (addressable ? Usage::Addressable : Usage::Unknown);
+    const Usage usage_mask = Usage::ShaderRead | (addressable ? Usage::Addressable : Usage::None);
     const Buffer::Settings settings{ Buffer::Type::Constant, usage_mask, size, 0U, PixelFormat::Unknown, Buffer::StorageMode::Managed };
     return std::make_shared<BufferVK>(dynamic_cast<ContextBase&>(context), settings, descriptor_by_usage);
 }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/BufferVK.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/BufferVK.cpp
@@ -27,6 +27,7 @@ Vulkan implementation of the buffer interface.
 #include <Methane/Graphics/ContextBase.h>
 #include <Methane/Instrumentation.h>
 
+#include <magic_enum.hpp>
 #include <iterator>
 
 namespace Methane::Graphics
@@ -49,6 +50,7 @@ Ptr<Buffer> Buffer::CreateIndexBuffer(Context& context, Data::Size size, PixelFo
 Ptr<Buffer> Buffer::CreateConstantBuffer(Context& context, Data::Size size, bool addressable, const DescriptorByUsage& descriptor_by_usage)
 {
     META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
     const Usage usage_mask = Usage::ShaderRead | (addressable ? Usage::Addressable : Usage::None);
     const Buffer::Settings settings{ Buffer::Type::Constant, usage_mask, size, 0U, PixelFormat::Unknown, Buffer::StorageMode::Private };
     return std::make_shared<BufferVK>(dynamic_cast<ContextBase&>(context), settings, descriptor_by_usage);
@@ -56,6 +58,8 @@ Ptr<Buffer> Buffer::CreateConstantBuffer(Context& context, Data::Size size, bool
 
 Ptr<Buffer> Buffer::CreateVolatileBuffer(Context& context, Data::Size size, bool addressable, const DescriptorByUsage& descriptor_by_usage)
 {
+    META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
     const Usage usage_mask = Usage::ShaderRead | (addressable ? Usage::Addressable : Usage::None);
     const Buffer::Settings settings{ Buffer::Type::Constant, usage_mask, size, 0U, PixelFormat::Unknown, Buffer::StorageMode::Managed };
     return std::make_shared<BufferVK>(dynamic_cast<ContextBase&>(context), settings, descriptor_by_usage);
@@ -77,14 +81,12 @@ BufferVK::BufferVK(ContextBase& context, const Settings& settings, const Descrip
 void BufferVK::SetName(const std::string& name)
 {
     META_FUNCTION_TASK();
-
     BufferBase::SetName(name);
 }
 
 void BufferVK::SetData(const SubResources& sub_resources)
 {
     META_FUNCTION_TASK();
-
     BufferBase::SetData(sub_resources);
 }
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/DeviceVK.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/DeviceVK.cpp
@@ -29,7 +29,7 @@ namespace Methane::Graphics
 {
 
 DeviceVK::DeviceVK()
-    : DeviceBase("", false, Device::Feature::Value::BasicRendering)
+    : DeviceBase("", false, Device::Features::BasicRendering)
 {
     META_FUNCTION_TASK();
 }
@@ -51,7 +51,7 @@ SystemVK::~SystemVK()
     META_FUNCTION_TASK();
 }
 
-const Ptrs<Device>& SystemVK::UpdateGpuDevices(Device::Feature::Mask supported_features)
+const Ptrs<Device>& SystemVK::UpdateGpuDevices(Device::Features supported_features)
 {
     META_FUNCTION_TASK();
     SetGpuSupportedFeatures(supported_features);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/DeviceVK.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/DeviceVK.h
@@ -41,7 +41,7 @@ public:
     ~SystemVK() override;
     
     void           CheckForChanges() override {}
-    const Ptrs<Device>& UpdateGpuDevices(Device::Feature::Mask supported_features) override;
+    const Ptrs<Device>& UpdateGpuDevices(Device::Features supported_features) override;
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ProgramBindingsVK.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ProgramBindingsVK.cpp
@@ -26,6 +26,8 @@ Vulkan implementation of the program interface.
 
 #include <Methane/Instrumentation.h>
 
+#include <magic_enum.hpp>
+
 namespace Methane::Graphics
 {
 
@@ -76,14 +78,18 @@ ProgramBindingsVK::ProgramBindingsVK(const ProgramBindingsVK& other_program_bind
 void ProgramBindingsVK::Apply(CommandListBase& command_list, ApplyBehavior apply_behavior) const
 {
     META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
 
     auto& vulkan_command_list = static_cast<RenderCommandListVK&>(command_list);
 
     for(const auto& binding_by_argument : GetArgumentBindings())
     {
         const auto& vulkan_argument_binding = static_cast<const ProgramBindingsVK::ArgumentBindingVK&>(*binding_by_argument.second);
-        if ((apply_behavior & ApplyBehavior::ConstantOnce || apply_behavior & ApplyBehavior::ChangesOnly) && vulkan_command_list.GetProgramBindings() &&
-            vulkan_argument_binding.IsAlreadyApplied(GetProgram(), *vulkan_command_list.GetProgramBindings(), apply_behavior & ApplyBehavior::ChangesOnly))
+        if ((magic_enum::flags::enum_contains(apply_behavior & ApplyBehavior::ConstantOnce) ||
+             magic_enum::flags::enum_contains(apply_behavior & ApplyBehavior::ChangesOnly)) &&
+             vulkan_command_list.GetProgramBindings() &&
+             vulkan_argument_binding.IsAlreadyApplied(GetProgram(), *vulkan_command_list.GetProgramBindings(),
+                                                      magic_enum::flags::enum_contains(apply_behavior & ApplyBehavior::ChangesOnly)))
             continue;
     }
 }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ProgramBindingsVK.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ProgramBindingsVK.cpp
@@ -73,7 +73,7 @@ ProgramBindingsVK::ProgramBindingsVK(const ProgramBindingsVK& other_program_bind
     META_FUNCTION_TASK();
 }
 
-void ProgramBindingsVK::Apply(CommandListBase& command_list, ApplyBehavior::Mask apply_behavior) const
+void ProgramBindingsVK::Apply(CommandListBase& command_list, ApplyBehavior apply_behavior) const
 {
     META_FUNCTION_TASK();
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ProgramBindingsVK.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ProgramBindingsVK.cpp
@@ -51,7 +51,7 @@ Ptr<ProgramBindingsBase::ArgumentBindingBase> ProgramBindingsBase::ArgumentBindi
 
 ProgramBindingsVK::ArgumentBindingVK::ArgumentBindingVK(const ContextBase& context, const SettingsVK& settings)
     : ArgumentBindingBase(context, settings)
-    , m_settings_vk(std::move(settings))
+    , m_settings_vk(settings)
 {
     META_FUNCTION_TASK();
 }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ProgramBindingsVK.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ProgramBindingsVK.h
@@ -54,7 +54,7 @@ public:
     ProgramBindingsVK(const ProgramBindingsVK& other_program_bindings, const ResourceLocationsByArgument& replace_resource_location_by_argument);
 
     // ProgramBindings interface
-    void Apply(CommandListBase& command_list, ApplyBehavior::Mask apply_behavior) const override;
+    void Apply(CommandListBase& command_list, ApplyBehavior apply_behavior) const override;
     
     // ProgramBindingsBase interface
     void CompleteInitialization() override { /* not implemented yet */ }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderCommandListVK.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderCommandListVK.cpp
@@ -32,6 +32,8 @@ Vulkan implementation of the render command list interface.
 #include <Methane/Instrumentation.h>
 #include <Methane/Checks.hpp>
 
+#include <magic_enum.hpp>
+
 namespace Methane::Graphics
 {
 
@@ -92,7 +94,8 @@ void RenderCommandListVK::SetVertexBuffers(BufferSet& vertex_buffers)
 
     RenderCommandListBase::SetVertexBuffers(vertex_buffers);
 
-    if (!(GetDrawingState().changes & DrawingState::Changes::VertexBuffers))
+    using namespace magic_enum::bitwise_operators;
+    if (!magic_enum::flags::enum_contains(GetDrawingState().changes & DrawingState::Changes::VertexBuffers))
         return;
 }
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderStateVK.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderStateVK.cpp
@@ -110,7 +110,7 @@ void RenderStateVK::Reset(const Settings& settings)
     ResetNativeState();
 }
 
-void RenderStateVK::Apply(RenderCommandListBase& /*command_list*/, Group::Mask /*state_groups*/)
+void RenderStateVK::Apply(RenderCommandListBase& /*command_list*/, Groups /*state_groups*/)
 {
     META_FUNCTION_TASK();
 }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderStateVK.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderStateVK.cpp
@@ -96,11 +96,6 @@ RenderStateVK::RenderStateVK(RenderContextBase& context, const Settings& setting
     Reset(settings);
 }
 
-RenderStateVK::~RenderStateVK()
-{
-    META_FUNCTION_TASK();
-}
-
 void RenderStateVK::Reset(const Settings& settings)
 {
     META_FUNCTION_TASK();

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderStateVK.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderStateVK.h
@@ -56,7 +56,7 @@ public:
     void Reset(const Settings& settings) override;
 
     // RenderStateBase interface
-    void Apply(RenderCommandListBase& command_list, Group::Mask state_groups) override;
+    void Apply(RenderCommandListBase& command_list, Groups state_groups) override;
 
     // Object interface
     void SetName(const std::string& name) override;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderStateVK.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderStateVK.h
@@ -50,7 +50,6 @@ class RenderStateVK final : public RenderStateBase
 {
 public:
     RenderStateVK(RenderContextBase& context, const Settings& settings);
-    ~RenderStateVK() override;
     
     // RenderState interface
     void Reset(const Settings& settings) override;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ResourceVK.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ResourceVK.h
@@ -53,7 +53,7 @@ public:
 protected:
     IContextVK& GetContextVK() noexcept
     {
-        return static_cast<IContextVK&>(ResourceBase::GetContextBase());
+        return dynamic_cast<IContextVK&>(ResourceBase::GetContextBase());
     }
 };
 

--- a/Modules/Graphics/Extensions/CMakeLists.txt
+++ b/Modules/Graphics/Extensions/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${TARGET}
         MethaneGraphicsPrimitives
         MethaneGraphicsCamera
         MethaneDataProvider
+        magic_enum
 )
 
 target_precompile_headers(${TARGET} REUSE_FROM MethanePrecompiledExtraHeaders)

--- a/Modules/Graphics/Extensions/Include/Methane/Graphics/ImageLoader.h
+++ b/Modules/Graphics/Extensions/Include/Methane/Graphics/ImageLoader.h
@@ -37,18 +37,12 @@ namespace Methane::Graphics
 class ImageLoader final
 {
 public:
-    struct Options
+    enum class Options : uint32_t
     {
-        using Mask = uint32_t;
-        enum Value : Mask
-        {
-            None            = 0U,
-            Mipmapped       = 1U << 0U,
-            SrgbColorSpace  = 1U << 1U,
-            All             = ~0U,
-        };
-
-        Options() = delete;
+        None            = 0U,
+        Mipmapped       = 1U << 0U,
+        SrgbColorSpace  = 1U << 1U,
+        All             = ~0U
     };
 
     class ImageData
@@ -77,19 +71,17 @@ public:
         PositiveY,
         NegativeY,
         PositiveZ,
-        NegativeZ,
-
-        Count
+        NegativeZ
     };
 
-    using CubeFaceResources = std::array<std::string, static_cast<size_t>(CubeFace::Count)>;
+    using CubeFaceResources = std::array<std::string, 6>;
 
     explicit ImageLoader(Data::Provider& data_provider);
 
     ImageData LoadImage(const std::string& image_path, size_t channels_count, bool create_copy);
 
-    Ptr<Texture> LoadImageToTexture2D(Context& context, const std::string& image_path, Options::Mask options = Options::None);
-    Ptr<Texture> LoadImagesToTextureCube(Context& context, const CubeFaceResources& image_paths, Options::Mask options = Options::None);
+    Ptr<Texture> LoadImageToTexture2D(Context& context, const std::string& image_path, Options options = Options::None);
+    Ptr<Texture> LoadImagesToTextureCube(Context& context, const CubeFaceResources& image_paths, Options options = Options::None);
 
 private:
     Data::Provider& m_data_provider;

--- a/Modules/Graphics/Extensions/Include/Methane/Graphics/ImageLoader.h
+++ b/Modules/Graphics/Extensions/Include/Methane/Graphics/ImageLoader.h
@@ -28,6 +28,7 @@ by decoding them from popular image formats.
 #include <Methane/Graphics/Texture.h>
 #include <Methane/Data/Provider.h>
 
+#include <magic_enum.hpp>
 #include <string>
 #include <array>
 
@@ -74,7 +75,7 @@ public:
         NegativeZ
     };
 
-    using CubeFaceResources = std::array<std::string, 6>;
+    using CubeFaceResources = std::array<std::string, magic_enum::enum_count<CubeFace>()>;
 
     explicit ImageLoader(Data::Provider& data_provider);
 

--- a/Modules/Graphics/Extensions/Include/Methane/Graphics/MeshBuffers.hpp
+++ b/Modules/Graphics/Extensions/Include/Methane/Graphics/MeshBuffers.hpp
@@ -115,15 +115,17 @@ public:
                              instance_count, start_instance);
     }
 
-    void Draw(RenderCommandList& cmd_list, const Ptrs<ProgramBindings>& instance_program_bindings, uint32_t first_instance_index = 0)
+    void Draw(RenderCommandList& cmd_list, const Ptrs<ProgramBindings>& instance_program_bindings,
+              ProgramBindings::ApplyBehavior bindings_apply_behavior = ProgramBindings::ApplyBehavior::AllIncremental,
+              uint32_t first_instance_index = 0)
     {
-        Draw(cmd_list, instance_program_bindings.begin(), instance_program_bindings.end(), first_instance_index);
+        Draw(cmd_list, instance_program_bindings.begin(), instance_program_bindings.end(), bindings_apply_behavior, first_instance_index);
     }
 
     void Draw(RenderCommandList& cmd_list,
               const Ptrs<ProgramBindings>::const_iterator& instance_program_bindings_begin,
               const Ptrs<ProgramBindings>::const_iterator& instance_program_bindings_end,
-              ProgramBindings::ApplyBehavior::Mask bindings_apply_behavior = ProgramBindings::ApplyBehavior::AllIncremental,
+              ProgramBindings::ApplyBehavior bindings_apply_behavior = ProgramBindings::ApplyBehavior::AllIncremental,
               uint32_t first_instance_index = 0)
     {
         META_FUNCTION_TASK();
@@ -153,7 +155,7 @@ public:
     }
 
     void DrawParallel(ParallelRenderCommandList& parallel_cmd_list, const Ptrs<ProgramBindings>& instance_program_bindings,
-                      ProgramBindings::ApplyBehavior::Mask bindings_apply_behavior = ProgramBindings::ApplyBehavior::AllIncremental)
+                      ProgramBindings::ApplyBehavior bindings_apply_behavior = ProgramBindings::ApplyBehavior::AllIncremental)
     {
         META_FUNCTION_TASK();
 

--- a/Modules/Graphics/Extensions/Include/Methane/Graphics/SkyBox.h
+++ b/Modules/Graphics/Extensions/Include/Methane/Graphics/SkyBox.h
@@ -44,18 +44,12 @@ class Camera;
 class SkyBox
 {
 public:
-    struct Options
+    enum class Options : uint32_t
     {
-        using Mask = uint32_t;
-        enum Value : Mask
-        {
-            None            = 0U,
-            DepthEnabled    = 1U << 0U,
-            DepthReversed   = 1U << 1U,
-            All             = ~0U,
-        };
-
-        Options() = delete;
+        None            = 0U,
+        DepthEnabled    = 1U << 0U,
+        DepthReversed   = 1U << 1U,
+        All             = ~0U,
     };
 
     struct Settings
@@ -63,9 +57,9 @@ public:
         const Camera&                  view_camera;
         ImageLoader::CubeFaceResources face_resources;
         float                          scale;
-        ImageLoader::Options::Mask     image_options  = ImageLoader::Options::None;
-        SkyBox::Options::Mask          render_options = SkyBox::Options::None;
-        float                          lod_bias = 0.F;
+        ImageLoader::Options     image_options  = ImageLoader::Options::None;
+        Options                        render_options = Options::None;
+        float                          lod_bias       = 0.F;
     };
 
     struct SHADER_STRUCT_ALIGN Uniforms

--- a/Modules/Graphics/Extensions/Sources/Methane/Graphics/SkyBox.cpp
+++ b/Modules/Graphics/Extensions/Sources/Methane/Graphics/SkyBox.cpp
@@ -28,6 +28,8 @@ SkyBox rendering primitive
 #include <Methane/Data/AppResourceProviders.h>
 #include <Methane/Instrumentation.h>
 
+#include <magic_enum.hpp>
+
 namespace Methane::Graphics
 {
 
@@ -77,10 +79,12 @@ SkyBox::SkyBox(RenderContext& context, ImageLoader& image_loader, const Settings
             context_settings.depth_stencil_format
         }
     );
+
+    using namespace magic_enum::bitwise_operators;
     state_settings.program_ptr->SetName("Sky-box shading");
-    state_settings.depth.enabled        = m_settings.render_options & Options::DepthEnabled;
+    state_settings.depth.enabled        = magic_enum::flags::enum_contains(m_settings.render_options & Options::DepthEnabled);
     state_settings.depth.write_enabled  = false;
-    state_settings.depth.compare        = m_settings.render_options & Options::DepthReversed ? Compare::GreaterEqual : Compare::Less;
+    state_settings.depth.compare        = magic_enum::flags::enum_contains(m_settings.render_options & Options::DepthReversed) ? Compare::GreaterEqual : Compare::Less;
     state_settings.rasterizer.is_front_counter_clockwise = true;
 
     m_render_state_ptr = RenderState::Create(context, state_settings);

--- a/Modules/Graphics/Primitives/Include/Methane/Graphics/Mesh.h
+++ b/Modules/Graphics/Primitives/Include/Methane/Graphics/Mesh.h
@@ -25,6 +25,7 @@ Abstract mesh class
 
 #include <Methane/Graphics/Types.h>
 
+#include <magic_enum.hpp>
 #include <vector>
 #include <array>
 #include <map>
@@ -80,9 +81,7 @@ public:
         Position = 0,
         Normal,
         TexCoord,
-        Color,
-
-        Count
+        Color
     };
 
     class VertexLayout : public std::vector<VertexField>
@@ -127,7 +126,7 @@ protected:
         bool operator<(const Edge& other) const;
     };
     
-    using VertexFieldOffsets = std::array<int32_t,     static_cast<size_t>(VertexField::Count)>;
+    using VertexFieldOffsets = std::array<int32_t, magic_enum::enum_count<VertexField>()>;
 
     bool HasVertexField(VertexField field) const noexcept;
     void CheckLayoutHasVertexField(VertexField field) const;

--- a/Modules/Graphics/Primitives/Sources/Methane/Graphics/Mesh.cpp
+++ b/Modules/Graphics/Primitives/Sources/Methane/Graphics/Mesh.cpp
@@ -37,7 +37,7 @@ static constexpr Data::Size g_colors_count = 6;
 
 Data::Size Mesh::GetVertexFieldSize(size_t vertex_field_index)
 {
-    static const std::array<Data::Size, static_cast<size_t>(VertexField::Count)> s_vertex_field_sizes {{
+    static const std::array<Data::Size, magic_enum::enum_count<VertexField>()> s_vertex_field_sizes {{
         sizeof(Position),
         sizeof(Normal),
         sizeof(TexCoord),

--- a/Modules/Graphics/Types/Include/Methane/Graphics/Color.hpp
+++ b/Modules/Graphics/Types/Include/Methane/Graphics/Color.hpp
@@ -40,11 +40,11 @@ public:
     using VectorType::VectorType;
     using VectorType::operator=;
 
-    ColorNf(const ColorNf<vector_size>& other) : VectorType(other) { }
-    ColorNf(ColorNf<vector_size>&& other) : VectorType(static_cast<VectorType&&>(other)) { }
+    ColorNf(const ColorNf& other) noexcept : VectorType(other) { }
+    ColorNf(ColorNf&& other) noexcept : VectorType(static_cast<VectorType&&>(other)) { }
 
-    ColorNf<vector_size>& operator=(const ColorNf<vector_size>& other) noexcept { VectorType::operator=(other); return *this; }
-    ColorNf<vector_size>& operator=(ColorNf<vector_size>&& other) noexcept      { VectorType::operator=(static_cast<VectorType&&>(other)); return *this; }
+    ColorNf& operator=(const ColorNf& other) noexcept { VectorType::operator=(other); return *this; }
+    ColorNf& operator=(ColorNf&& other) noexcept      { VectorType::operator=(static_cast<VectorType&&>(other)); return *this; }
 
     float GetRf() const noexcept { return (*this)[0]; }
     float GetGf() const noexcept { return (*this)[1]; }

--- a/Modules/Graphics/Types/Include/Methane/Graphics/Color.hpp
+++ b/Modules/Graphics/Types/Include/Methane/Graphics/Color.hpp
@@ -40,11 +40,17 @@ public:
     using VectorType::VectorType;
     using VectorType::operator=;
 
+    ColorNf(const ColorNf<vector_size>& other) : VectorType(other) { }
+    ColorNf(ColorNf<vector_size>&& other) : VectorType(static_cast<VectorType&&>(other)) { }
+
+    ColorNf<vector_size>& operator=(const ColorNf<vector_size>& other) noexcept { VectorType::operator=(other); return *this; }
+    ColorNf<vector_size>& operator=(ColorNf<vector_size>&& other) noexcept      { VectorType::operator=(static_cast<VectorType&&>(other)); return *this; }
+
     float GetRf() const noexcept { return (*this)[0]; }
     float GetGf() const noexcept { return (*this)[1]; }
     float GetBf() const noexcept { return (*this)[2]; }
 
-    template<size_t sz = vector_size, typename = std::enable_if_t<sz >= 4, void>>
+    template<size_t sz = vector_size, typename = std::enable_if_t<sz>= 4, void>>
     float GetAf() const noexcept { return (*this)[3]; }
 
     float GetNormRf() const noexcept { return GetNormColorComponent(GetRf()); }

--- a/Modules/Graphics/Types/Include/Methane/Graphics/Color.hpp
+++ b/Modules/Graphics/Types/Include/Methane/Graphics/Color.hpp
@@ -34,17 +34,19 @@ namespace Methane::Graphics
 {
 
 template<size_t vector_size, typename VectorType = std::enable_if_t<3 <= vector_size && vector_size <= 4, cml::vector<float, cml::fixed<vector_size>>>>
-class ColorNf : public VectorType
+class ColorF : public VectorType
 {
 public:
     using VectorType::VectorType;
     using VectorType::operator=;
 
-    ColorNf(const ColorNf& other) noexcept : VectorType(other) { }
-    ColorNf(ColorNf&& other) noexcept : VectorType(static_cast<VectorType&&>(other)) { }
+    ~ColorF() = default;
 
-    ColorNf& operator=(const ColorNf& other) noexcept { VectorType::operator=(other); return *this; }
-    ColorNf& operator=(ColorNf&& other) noexcept      { VectorType::operator=(static_cast<VectorType&&>(other)); return *this; }
+    ColorF(const ColorF& other) noexcept : VectorType(other) { }
+    ColorF(ColorF&& other) noexcept : VectorType(static_cast<VectorType&&>(other)) { }
+
+    ColorF& operator=(const ColorF& other) noexcept { VectorType::operator=(other); return *this; }
+    ColorF& operator=(ColorF&& other) noexcept      { VectorType::operator=(static_cast<VectorType&&>(other)); return *this; }
 
     float GetRf() const noexcept { return (*this)[0]; }
     float GetGf() const noexcept { return (*this)[1]; }
@@ -97,7 +99,7 @@ private:
     static constexpr uint8_t s_uint_component_max = std::numeric_limits<uint8_t>::max();
 };
 
-using Color3f = ColorNf<3>;
-using Color4f = ColorNf<4>;
+using Color3f = ColorF<3>;
+using Color4f = ColorF<4>;
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Types/Include/Methane/Graphics/TypeFormatters.hpp
+++ b/Modules/Graphics/Types/Include/Methane/Graphics/TypeFormatters.hpp
@@ -72,9 +72,9 @@ struct fmt::formatter<Methane::Graphics::Volume<T, D>>
 };
 
 template<size_t color_size>
-struct fmt::formatter<Methane::Graphics::ColorNf<color_size>>
+struct fmt::formatter<Methane::Graphics::ColorF<color_size>>
 {
     template<typename FormatContext>
-    auto format(const Methane::Graphics::ColorNf<color_size>& color, FormatContext& ctx) { return format_to(ctx.out(), "{}", static_cast<std::string>(color)); }
+    auto format(const Methane::Graphics::ColorF<color_size>& color, FormatContext& ctx) { return format_to(ctx.out(), "{}", static_cast<std::string>(color)); }
     constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
 };

--- a/Modules/Platform/App/Include/Methane/Platform/AppController.h
+++ b/Modules/Platform/App/Include/Methane/Platform/AppController.h
@@ -29,17 +29,14 @@ Base application controller providing commands like app close and help.
 namespace Methane::Platform
 {
 
-enum class AppAction : uint32_t
+enum class AppAction
 {
-    None = 0,
-    
+    None,
     ShowControlsHelp,
     ShowCommandLineHelp,
     ShowParameters,
     SwitchFullScreen,
-    CloseApp,
-    
-    Count
+    CloseApp
 };
 
 class AppController

--- a/Modules/Platform/Input/CMakeLists.txt
+++ b/Modules/Platform/Input/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(${TARGET}
         MethanePrecompiledHeaders
         MethanePrimitives
         MethanePlatformUtils
+        magic_enum
         ${PLATFORM_LIBRARIES}
 )
 

--- a/Modules/Platform/Input/Include/Methane/Platform/Input/Controller.h
+++ b/Modules/Platform/Input/Include/Methane/Platform/Input/Controller.h
@@ -38,7 +38,7 @@ struct IActionController
     virtual void OnMouseScrollChanged(const Mouse::Scroll& mouse_scroll_delta) = 0;
     virtual void OnMouseInWindowChanged(bool is_mouse_in_window) = 0;
     virtual void OnKeyboardChanged(Keyboard::Key key, Keyboard::KeyState key_state) = 0;
-    virtual void OnModifiersChanged(Keyboard::Modifier::Mask modifiers) = 0;
+    virtual void OnModifiersChanged(Keyboard::Modifiers modifiers) = 0;
 
     virtual ~IActionController() = default;
 };
@@ -50,7 +50,7 @@ struct IController
     virtual void OnMouseScrollChanged(const Mouse::Scroll& mouse_scroll_delta, const Mouse::StateChange& state_change) = 0;
     virtual void OnMouseInWindowChanged(bool is_mouse_in_window, const Mouse::StateChange& state_change) = 0;
     virtual void OnKeyboardChanged(Keyboard::Key key, Keyboard::KeyState key_state, const Keyboard::StateChange& state_change) = 0;
-    virtual void OnModifiersChanged(Keyboard::Modifier::Mask modifiers, const Keyboard::StateChange& state_change) = 0;
+    virtual void OnModifiersChanged(Keyboard::Modifiers modifiers, const Keyboard::StateChange& state_change) = 0;
 
     virtual ~IController() = default;
 };
@@ -72,7 +72,7 @@ public:
     void OnMouseScrollChanged(const Mouse::Scroll& /*mouse_scroll_delta*/, const Mouse::StateChange& /*state_change*/) override { }
     void OnMouseInWindowChanged(bool /*is_mouse_in_window*/, const Mouse::StateChange& /*state_change*/) override { }
     void OnKeyboardChanged(Keyboard::Key /*key*/, Keyboard::KeyState /*key_state*/, const Keyboard::StateChange& /*state_change*/) override { }
-    void OnModifiersChanged(Keyboard::Modifier::Mask /*modifiers*/, const Keyboard::StateChange& /*state_change*/) override { }
+    void OnModifiersChanged(Keyboard::Modifiers /*modifiers*/, const Keyboard::StateChange& /*state_change*/) override { }
     
     // IHelpProvider - overrides are optional
     HelpLines GetHelp() const override { return HelpLines(); }

--- a/Modules/Platform/Input/Include/Methane/Platform/Input/ControllersPool.h
+++ b/Modules/Platform/Input/Include/Methane/Platform/Input/ControllersPool.h
@@ -45,7 +45,7 @@ public:
     void OnMouseScrollChanged(const Mouse::Scroll& mouse_scroll_delta, const Mouse::StateChange& state_change) override;
     void OnMouseInWindowChanged(bool is_mouse_in_window, const Mouse::StateChange& state_change) override;
     void OnKeyboardChanged(Keyboard::Key key, Keyboard::KeyState key_state, const Keyboard::StateChange& state_change) override;
-    void OnModifiersChanged(Keyboard::Modifier::Mask modifiers, const Keyboard::StateChange& state_change) override;
+    void OnModifiersChanged(Keyboard::Modifiers modifiers, const Keyboard::StateChange& state_change) override;
 
     // IHelpProvider implementation
     HelpLines GetHelp() const override;

--- a/Modules/Platform/Input/Include/Methane/Platform/Input/State.h
+++ b/Modules/Platform/Input/Include/Methane/Platform/Input/State.h
@@ -48,7 +48,7 @@ public:
     void OnMouseScrollChanged(const Mouse::Scroll& mouse_scroll_delta) override;
     void OnMouseInWindowChanged(bool is_mouse_in_window) override;
     void OnKeyboardChanged(Keyboard::Key key, Keyboard::KeyState key_state) override;
-    void OnModifiersChanged(Keyboard::Modifier::Mask modifiers) override;
+    void OnModifiersChanged(Keyboard::Modifiers modifiers) override;
 
     void ReleaseAllKeys();
 

--- a/Modules/Platform/Input/Include/Methane/Platform/Keyboard.h
+++ b/Modules/Platform/Input/Include/Methane/Platform/Keyboard.h
@@ -37,6 +37,7 @@ Platform abstraction of keyboard events.
 
 #endif
 
+#include <magic_enum.hpp>
 #include <array>
 #include <set>
 #include <string>
@@ -84,7 +85,7 @@ enum class Key : uint32_t
     RightShift, RightControl, RightAlt, RightSuper,
     Menu,
 
-    Count,
+    // Always keep at the end
     Unknown
 };
 
@@ -153,7 +154,7 @@ enum class KeyState : uint8_t
     Pressed,
 };
 
-using KeyStates = std::array<KeyState, static_cast<size_t>(Key::Count)>;
+using KeyStates = std::array<KeyState, magic_enum::enum_count<Key>() - 1>;
 
 class State
 {

--- a/Modules/Platform/Input/Include/Methane/Platform/Keyboard.h
+++ b/Modules/Platform/Input/Include/Methane/Platform/Keyboard.h
@@ -144,6 +144,7 @@ public:
 private:
     const Key       m_key;
     const Modifiers m_modifiers;
+    static Key GetControlKey(const NativeKey& native_key);
 };
 
 enum class KeyState : uint8_t

--- a/Modules/Platform/Input/Include/Methane/Platform/KeyboardActionControllerBase.hpp
+++ b/Modules/Platform/Input/Include/Methane/Platform/KeyboardActionControllerBase.hpp
@@ -51,7 +51,7 @@ public:
     void OnKeyboardChanged(Key button, KeyState key_state, const StateChange& state_change)
     {
         META_FUNCTION_TASK();
-        if (state_change.changed_properties == State::Property::None)
+        if (state_change.changed_properties == State::Properties::None)
             return;
         
         const auto action_by_keyboard_state_it = m_action_by_keyboard_state.find(state_change.current);

--- a/Modules/Platform/Input/Include/Methane/Platform/KeyboardActionControllerBase.hpp
+++ b/Modules/Platform/Input/Include/Methane/Platform/KeyboardActionControllerBase.hpp
@@ -28,6 +28,7 @@
 
 #include <Methane/Instrumentation.h>
 
+#include <magic_enum.hpp>
 #include <map>
 
 namespace Methane::Platform::Keyboard
@@ -75,10 +76,8 @@ public:
             return help_lines;
         
         help_lines.reserve(m_action_by_keyboard_key.size() + m_action_by_keyboard_state.size());
-        for (uint32_t action_index = 0; action_index < static_cast<uint32_t>(ActionEnum::Count); ++action_index)
+        for (const ActionEnum action : magic_enum::enum_values<ActionEnum>())
         {
-            const ActionEnum action = static_cast<ActionEnum>(action_index);
-            
             const auto action_by_keyboard_state_it = std::find_if(m_action_by_keyboard_state.begin(), m_action_by_keyboard_state.end(),
                                                                   [action](const std::pair<Keyboard::State, ActionEnum>& keys_and_action)
                                                                   { return keys_and_action.second == action; });

--- a/Modules/Platform/Input/Include/Methane/Platform/Mouse.h
+++ b/Modules/Platform/Input/Include/Methane/Platform/Mouse.h
@@ -36,7 +36,7 @@ namespace Methane::Platform::Mouse
 
 enum class Button : uint32_t
 {
-    Left        = 0,
+    Left = 0U,
     Right,
     Middle,
     Button4,
@@ -47,7 +47,6 @@ enum class Button : uint32_t
     VScroll,
     HScroll,
 
-    Count,
     Unknown
 };
 
@@ -56,7 +55,7 @@ using Buttons = std::set<Button>;
 class ButtonConverter
 {
 public:
-    ButtonConverter(Button button) : m_button(button) { }
+    explicit ButtonConverter(Button button) : m_button(button) { }
     
     std::string ToString() const;
     
@@ -70,7 +69,7 @@ enum class ButtonState : uint8_t
     Pressed,
 };
 
-using ButtonStates = std::array<ButtonState, static_cast<size_t>(Button::Count)>;
+using ButtonStates = std::array<ButtonState, magic_enum::enum_count<Button>() - 1>;
 
 using Position = Data::Point2i;
 using Scroll = Data::Point2f;
@@ -99,9 +98,7 @@ public:
 
     State() = default;
     State(std::initializer_list<Button> pressed_buttons, const Position& position = Position(), const Scroll& scroll = Scroll(), bool in_window = false);
-    State(const State& other);
 
-    State& operator=(const State& other);
     bool operator==(const State& other) const;
     bool operator!=(const State& other) const                   { return !operator==(other); }
     const ButtonState& operator[](Button button) const          { return m_button_states[static_cast<size_t>(button)]; }

--- a/Modules/Platform/Input/Include/Methane/Platform/Mouse.h
+++ b/Modules/Platform/Input/Include/Methane/Platform/Mouse.h
@@ -87,27 +87,14 @@ inline MouseButtonAndDelta GetScrollButtonAndDelta(const Scroll& scroll_delta)
 class State
 {
 public:
-    struct Property
+    enum class Properties : uint32_t
     {
-        using Mask = uint32_t;
-        enum Value : Mask
-        {
-            None        = 0U,
-            Buttons     = 1U << 0U,
-            Position    = 1U << 1U,
-            Scroll      = 1U << 2U,
-            InWindow    = 1U << 3U,
-            All         = ~0U,
-        };
-
-        using Values = std::array<Value, 4>;
-        static constexpr const Values values{ Buttons, Position, Scroll, InWindow };
-
-        static std::string ToString(Value property_value);
-        static std::string ToString(Mask properties_mask);
-
-        Property() = delete;
-        ~Property() = delete;
+        None        = 0U,
+        Buttons     = 1U << 0U,
+        Position    = 1U << 1U,
+        Scroll      = 1U << 2U,
+        InWindow    = 1U << 3U,
+        All         = ~0U
     };
 
     State() = default;
@@ -118,7 +105,7 @@ public:
     bool operator==(const State& other) const;
     bool operator!=(const State& other) const                   { return !operator==(other); }
     const ButtonState& operator[](Button button) const          { return m_button_states[static_cast<size_t>(button)]; }
-    operator std::string() const                                { return ToString(); }
+    explicit operator std::string() const                       { return ToString(); }
 
     void  SetButton(Button button, ButtonState state)           { m_button_states[static_cast<size_t>(button)] = state; }
     void  PressButton(Button button)                            { SetButton(button, ButtonState::Pressed); }
@@ -136,7 +123,7 @@ public:
 
     Buttons             GetPressedButtons() const;
     const ButtonStates& GetButtonStates() const                 { return m_button_states; }
-    Property::Mask      GetDiff(const State& other) const;
+    Properties          GetDiff(const State& other) const;
     std::string         ToString() const;
 
 private:
@@ -154,7 +141,7 @@ inline std::ostream& operator<<( std::ostream& os, State const& keyboard_state)
 
 struct StateChange
 {
-    StateChange(const State& in_current, const State& in_previous, State::Property::Mask in_changed_properties)
+    StateChange(const State& in_current, const State& in_previous, State::Properties in_changed_properties)
         : current(in_current)
         , previous(in_previous)
         , changed_properties(in_changed_properties)
@@ -162,7 +149,7 @@ struct StateChange
 
     const State& current;
     const State& previous;
-    const State::Property::Mask changed_properties;
+    const State::Properties changed_properties;
 };
 
 } // namespace Methane::Platform::Mouse

--- a/Modules/Platform/Input/Include/Methane/Platform/MouseActionControllerBase.hpp
+++ b/Modules/Platform/Input/Include/Methane/Platform/MouseActionControllerBase.hpp
@@ -26,6 +26,7 @@
 #include "Input/HelpProvider.h"
 #include "Mouse.h"
 
+#include <magic_enum.hpp>
 #include <map>
 
 namespace Methane::Platform::Mouse
@@ -51,9 +52,8 @@ public:
             return help_lines;
         
         help_lines.reserve(m_action_by_mouse_button.size());
-        for (uint32_t action_index = 0; action_index < static_cast<uint32_t>(ActionEnum::Count); ++action_index)
+        for (const ActionEnum action : magic_enum::enum_values<ActionEnum>())
         {
-            const ActionEnum action = static_cast<ActionEnum>(action_index);
             const auto action_by_mouse_button_it = std::find_if(m_action_by_mouse_button.begin(), m_action_by_mouse_button.end(),
                                                                 [action](const std::pair<Button, ActionEnum>& button_and_action)
                                                                 {

--- a/Modules/Platform/Input/Sources/Methane/Platform/Input/ControllersPool.cpp
+++ b/Modules/Platform/Input/Sources/Methane/Platform/Input/ControllersPool.cpp
@@ -113,7 +113,7 @@ void ControllersPool::OnKeyboardChanged(Keyboard::Key key, Keyboard::KeyState ke
     }
 }
 
-void ControllersPool::OnModifiersChanged(Keyboard::Modifier::Mask modifiers, const Keyboard::StateChange& state_change)
+void ControllersPool::OnModifiersChanged(Keyboard::Modifiers modifiers, const Keyboard::StateChange& state_change)
 {
     META_FUNCTION_TASK();
     META_FUNCTION_THREAD_MARKER();

--- a/Modules/Platform/Input/Sources/Methane/Platform/Input/State.cpp
+++ b/Modules/Platform/Input/Sources/Methane/Platform/Input/State.cpp
@@ -38,7 +38,7 @@ void State::OnMouseButtonChanged(Mouse::Button button, Mouse::ButtonState button
     if (m_mouse_state == prev_mouse_state)
         return;
 
-    m_controllers.OnMouseButtonChanged(button, button_state, Mouse::StateChange(m_mouse_state, prev_mouse_state, Mouse::State::Property::Buttons));
+    m_controllers.OnMouseButtonChanged(button, button_state, Mouse::StateChange(m_mouse_state, prev_mouse_state, Mouse::State::Properties::Buttons));
 }
 
 void State::OnMousePositionChanged(const Mouse::Position& mouse_position)
@@ -51,7 +51,7 @@ void State::OnMousePositionChanged(const Mouse::Position& mouse_position)
     if (m_mouse_state == prev_mouse_state)
         return;
 
-    m_controllers.OnMousePositionChanged(mouse_position, Mouse::StateChange(m_mouse_state, prev_mouse_state, Mouse::State::Property::Position));
+    m_controllers.OnMousePositionChanged(mouse_position, Mouse::StateChange(m_mouse_state, prev_mouse_state, Mouse::State::Properties::Position));
 }
 
 void State::OnMouseScrollChanged(const Mouse::Scroll& mouse_scroll_delta)
@@ -64,7 +64,7 @@ void State::OnMouseScrollChanged(const Mouse::Scroll& mouse_scroll_delta)
     if (m_mouse_state == prev_mouse_state)
         return;
 
-    m_controllers.OnMouseScrollChanged(mouse_scroll_delta, Mouse::StateChange(m_mouse_state, prev_mouse_state, Mouse::State::Property::Scroll));
+    m_controllers.OnMouseScrollChanged(mouse_scroll_delta, Mouse::StateChange(m_mouse_state, prev_mouse_state, Mouse::State::Properties::Scroll));
 }
 
 void State::OnMouseInWindowChanged(bool is_mouse_in_window)
@@ -77,7 +77,7 @@ void State::OnMouseInWindowChanged(bool is_mouse_in_window)
     if (m_mouse_state == prev_mouse_state)
         return;
 
-    m_controllers.OnMouseInWindowChanged(is_mouse_in_window, Mouse::StateChange(m_mouse_state, prev_mouse_state, Mouse::State::Property::InWindow));
+    m_controllers.OnMouseInWindowChanged(is_mouse_in_window, Mouse::StateChange(m_mouse_state, prev_mouse_state, Mouse::State::Properties::InWindow));
 }
 
 void State::OnKeyboardChanged(Keyboard::Key key, Keyboard::KeyState key_state)
@@ -86,23 +86,23 @@ void State::OnKeyboardChanged(Keyboard::Key key, Keyboard::KeyState key_state)
 
     Keyboard::State prev_keyboard_state(static_cast<const Keyboard::State&>(m_keyboard_state));
     m_keyboard_state.SetKey(key, key_state);
-    Keyboard::State::Property::Mask state_changes_mask = m_keyboard_state.GetDiff(prev_keyboard_state);
+    Keyboard::State::Properties state_changes_mask = m_keyboard_state.GetDiff(prev_keyboard_state);
 
-    if (state_changes_mask == Keyboard::State::Property::None)
+    if (state_changes_mask == Keyboard::State::Properties::None)
         return;
 
     m_controllers.OnKeyboardChanged(key, key_state, Keyboard::StateChange(m_keyboard_state, prev_keyboard_state, state_changes_mask));
 }
 
-void State::OnModifiersChanged(Keyboard::Modifier::Mask modifiers_mask)
+void State::OnModifiersChanged(Keyboard::Modifiers modifiers_mask)
 {
     META_FUNCTION_TASK();
 
     Keyboard::State prev_keyboard_state(static_cast<const Keyboard::State&>(m_keyboard_state));
     m_keyboard_state.SetModifiersMask(modifiers_mask);
-    Keyboard::State::Property::Mask state_changes_mask = m_keyboard_state.GetDiff(prev_keyboard_state);
+    Keyboard::State::Properties state_changes_mask = m_keyboard_state.GetDiff(prev_keyboard_state);
     
-    if (state_changes_mask == Keyboard::State::Property::None)
+    if (state_changes_mask == Keyboard::State::Properties::None)
         return;
     
     m_controllers.OnModifiersChanged(modifiers_mask, Keyboard::StateChange(m_keyboard_state, prev_keyboard_state, state_changes_mask));

--- a/Modules/Platform/Input/Sources/Methane/Platform/Keyboard.cpp
+++ b/Modules/Platform/Input/Sources/Methane/Platform/Keyboard.cpp
@@ -25,6 +25,8 @@ Platform abstraction of keyboard events.
 #include <Methane/Instrumentation.h>
 #include <Methane/Checks.hpp>
 
+#include <fmt/format.h>
+#include <magic_enum.hpp>
 #include <map>
 #include <sstream>
 
@@ -41,7 +43,7 @@ KeyConverter::KeyConverter(Key key)
     META_FUNCTION_TASK();
 }
 
-KeyConverter::KeyConverter(Key key, Modifier::Mask modifiers)
+KeyConverter::KeyConverter(Key key, Modifiers modifiers)
     : m_key(key)
     , m_modifiers(modifiers)
 {
@@ -55,34 +57,34 @@ KeyConverter::KeyConverter(const NativeKey& native_key)
     META_FUNCTION_TASK();
 }
 
-Modifier::Value KeyConverter::GetModifierKey() const noexcept
+Modifiers KeyConverter::GetModifierKey() const noexcept
 {
     META_FUNCTION_TASK();
     switch (m_key)
     {
     case Key::LeftShift:
     case Key::RightShift:
-        return Modifier::Shift;
+        return Modifiers::Shift;
 
     case Key::LeftControl:
     case Key::RightControl:
-        return Modifier::Control;
+        return Modifiers::Control;
 
     case Key::LeftAlt:
     case Key::RightAlt:
-        return Modifier::Alt;
+        return Modifiers::Alt;
 
     case Key::LeftSuper:
     case Key::RightSuper:
-        return Modifier::Super;
+        return Modifiers::Super;
 
     case Key::CapsLock:
-        return Modifier::CapsLock;
+        return Modifiers::CapsLock;
     case Key::NumLock:
-        return Modifier::NumLock;
+        return Modifiers::NumLock;
 
     default:
-        return Modifier::None;
+        return Modifiers::None;
     }
 }
 
@@ -228,12 +230,12 @@ std::string KeyConverter::ToString() const
     auto key_and_name_it = s_name_by_key.find(m_key);
     META_CHECK_ARG_DESCR(m_key, key_and_name_it != s_name_by_key.end(), "key name was not found");
 
-    return m_modifiers == Modifier::Value::None
+    return m_modifiers == Modifiers::None
            ? key_and_name_it->second
-           : Modifier::ToString(m_modifiers) + g_keys_separator + key_and_name_it->second;
+           : fmt::format("{}{}{}", magic_enum::enum_name(m_modifiers), g_keys_separator, key_and_name_it->second);
 };
 
-State::State(std::initializer_list<Key> pressed_keys, Modifier::Mask modifiers_mask)
+State::State(std::initializer_list<Key> pressed_keys, Modifiers modifiers_mask)
     : m_modifiers_mask(modifiers_mask)
 {
     META_FUNCTION_TASK();
@@ -285,16 +287,18 @@ State::operator bool() const noexcept
     return operator!=(s_empty_state);
 }
 
-State::Property::Mask State::GetDiff(const State& other) const noexcept
+State::Properties State::GetDiff(const State& other) const noexcept
 {
     META_FUNCTION_TASK();
-    State::Property::Mask properties_diff_mask = State::Property::None;
+    using namespace magic_enum::bitwise_operators;
+
+    State::Properties properties_diff_mask = State::Properties::None;
 
     if (m_key_states != other.m_key_states)
-        properties_diff_mask |= State::Property::KeyStates;
+        properties_diff_mask |= State::Properties::KeyStates;
 
     if (m_modifiers_mask != other.m_modifiers_mask)
-        properties_diff_mask |= State::Property::Modifiers;
+        properties_diff_mask |= State::Properties::Modifiers;
 
     return properties_diff_mask;
 }
@@ -305,8 +309,8 @@ KeyType State::SetKey(Key key, KeyState state)
     if (key == Key::Unknown)
         return KeyType::Common;
 
-    const Modifier::Value key_modifier = KeyConverter(key).GetModifierKey();
-    if (key_modifier != Modifier::Value::None)
+    const Modifiers key_modifier = KeyConverter(key).GetModifierKey();
+    if (key_modifier != Modifiers::None)
     {
         UpdateModifiersMask(key_modifier, state == KeyState::Pressed);
         return KeyType::Common;
@@ -320,9 +324,11 @@ KeyType State::SetKey(Key key, KeyState state)
     }
 }
 
-void State::UpdateModifiersMask(Modifier::Value modifier, bool add_modifier) noexcept
+void State::UpdateModifiersMask(Modifiers modifier, bool add_modifier) noexcept
 {
     META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
+
     if (add_modifier)
         m_modifiers_mask |= modifier;
     else
@@ -370,88 +376,14 @@ Keys StateExt::GetAllPressedKeys() const
     return all_pressed_keys;
 }
 
-std::string Modifier::ToString(Value modifier)
-{
-    META_FUNCTION_TASK();
-    switch(modifier)
-    {
-        case None:      return "None";
-        case Shift:     return "Shift";
-        case Control:   return "Control";
-        case Alt:       return "Alt";
-        case CapsLock:  return "CapsLock";
-        case NumLock:   return "NumLock";
-        case All:       return "All";
-#ifdef __APPLE__
-        case Super:     return "Command";
-#else
-        case Super:     return "Super";
-#endif
-        default:        return "Undefined";
-    }
-}
-
-std::string Modifier::ToString(Modifier::Mask modifiers_mask)
-{
-    META_FUNCTION_TASK();
-    std::stringstream ss;
-    bool first_modifier = true;
-    for(Value modifier : values)
-    {
-        if (modifiers_mask & modifier)
-        {
-            if (!first_modifier)
-            {
-                ss << g_keys_separator;
-            }
-            ss << ToString(modifier);
-            first_modifier = false;
-        }
-    }
-    return ss.str();
-}
-
-std::string State::Property::ToString(State::Property::Value property_value)
-{
-    META_FUNCTION_TASK();
-    switch (property_value)
-    {
-    case All:       return "All";
-    case KeyStates: return "KeyStates";
-    case Modifiers: return "Modifiers";
-    case None:      return "None";
-    default:        META_UNEXPECTED_ENUM_ARG_RETURN(property_value, "Undefined");
-    }
-}
-
-std::string State::Property::ToString(State::Property::Mask properties_mask)
-{
-    META_FUNCTION_TASK();
-    std::stringstream ss;
-    bool first_property = true;
-    for (Value property_value : values)
-    {
-        if (!(properties_mask & property_value))
-            continue;
-
-        if (!first_property)
-        {
-            ss << g_properties_separator;
-        }
-        ss << ToString(property_value);
-        first_property = false;
-    }
-    return ss.str();
-}
-
 std::string State::ToString() const
 {
     META_FUNCTION_TASK();
     std::stringstream ss;
-    const std::string modifiers_str = Modifier::ToString(m_modifiers_mask);
-    if (!modifiers_str.empty())
+    const bool has_modifiers = m_modifiers_mask != Modifiers::None;
+    if (has_modifiers)
     {
-        ss << modifiers_str;
+        ss << magic_enum::enum_name(m_modifiers_mask);
     }
     
     bool is_first_key = true;
@@ -460,7 +392,7 @@ std::string State::ToString() const
         if (m_key_states[key_index] != KeyState::Pressed)
             continue;
         
-        if (!is_first_key || !modifiers_str.empty())
+        if (!is_first_key || has_modifiers)
         {
             ss << g_keys_separator;
         }

--- a/Modules/Platform/Input/Sources/Methane/Platform/Linux/Keyboard.cpp
+++ b/Modules/Platform/Input/Sources/Methane/Platform/Linux/Keyboard.cpp
@@ -155,11 +155,11 @@ Key KeyConverter::GetKeyByNativeCode(const NativeKey& native_key)
     return native_code_and_key_it == s_key_by_native_code.end() ? Key::Unknown : native_code_and_key_it->second;
 }
 
-Modifier::Mask KeyConverter::GetModifiersByNativeCode(const NativeKey& /*native_key*/)
+Modifiers KeyConverter::GetModifiersByNativeCode(const NativeKey& /*native_key*/)
 {
     META_FUNCTION_TASK();
 
-    Modifier::Mask modifiers_mask = Modifier::Value::None;
+    Modifiers modifiers_mask = Modifiers::None;
     return modifiers_mask;
 }
 

--- a/Modules/Platform/Input/Sources/Methane/Platform/MacOS/Keyboard.mm
+++ b/Modules/Platform/Input/Sources/Methane/Platform/MacOS/Keyboard.mm
@@ -27,6 +27,7 @@ MacOS platform specific types and implementation of Keyboard abstractions.
 #import <AppKit/AppKit.h>
 
 #include <map>
+#include <magic_enum.hpp>
 
 namespace Methane::Platform::Keyboard
 {
@@ -160,6 +161,8 @@ Key KeyConverter::GetKeyByNativeCode(const NativeKey& native_key)
 Modifiers KeyConverter::GetModifiersByNativeCode(const NativeKey& native_key)
 {
     META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
+
     Modifiers modifiers_mask = Modifiers::None;
     
     if (native_key.flags & NSEventModifierFlagShift)

--- a/Modules/Platform/Input/Sources/Methane/Platform/MacOS/Keyboard.mm
+++ b/Modules/Platform/Input/Sources/Methane/Platform/MacOS/Keyboard.mm
@@ -157,28 +157,28 @@ Key KeyConverter::GetKeyByNativeCode(const NativeKey& native_key)
     return native_code_and_key_it == s_key_by_native_code.end() ? Key::Unknown : native_code_and_key_it->second;
 }
 
-Modifier::Mask KeyConverter::GetModifiersByNativeCode(const NativeKey& native_key)
+Modifiers KeyConverter::GetModifiersByNativeCode(const NativeKey& native_key)
 {
     META_FUNCTION_TASK();
-    Modifier::Mask modifiers_mask = Modifier::Value::None;
+    Modifiers modifiers_mask = Modifiers::None;
     
     if (native_key.flags & NSEventModifierFlagShift)
-        modifiers_mask |= Modifier::Value::Shift;
+        modifiers_mask |= Modifiers::Shift;
     
     if (native_key.flags & NSEventModifierFlagControl)
-        modifiers_mask |= Modifier::Value::Control;
+        modifiers_mask |= Modifiers::Control;
     
     if (native_key.flags & NSEventModifierFlagOption)
-        modifiers_mask |= Modifier::Value::Alt;
+        modifiers_mask |= Modifiers::Alt;
     
     if (native_key.flags & NSEventModifierFlagCommand)
-        modifiers_mask |= Modifier::Value::Super;
+        modifiers_mask |= Modifiers::Super;
     
     if (native_key.flags & NSEventModifierFlagCapsLock)
-        modifiers_mask |= Modifier::Value::CapsLock;
+        modifiers_mask |= Modifiers::CapsLock;
     
     if (native_key.flags & NSEventModifierFlagNumericPad)
-        modifiers_mask |= Modifier::Value::NumLock;
+        modifiers_mask |= Modifiers::NumLock;
     
     return modifiers_mask;
 }

--- a/Modules/Platform/Input/Sources/Methane/Platform/Mouse.cpp
+++ b/Modules/Platform/Input/Sources/Methane/Platform/Mouse.cpp
@@ -25,6 +25,7 @@ Platform abstraction of mouse events.
 #include <Methane/Instrumentation.h>
 #include <Methane/Checks.hpp>
 
+#include <magic_enum.hpp>
 #include <map>
 #include <sstream>
 
@@ -56,41 +57,6 @@ std::string ButtonConverter::ToString() const
 
     return button_and_name_it->second;
 };
-
-std::string State::Property::ToString(State::Property::Value property_value)
-{
-    META_FUNCTION_TASK();
-    switch (property_value)
-    {
-    case All:       return "All";
-    case Buttons:   return "Buttons";
-    case Position:  return "Position";
-    case Scroll:    return "Scroll";
-    case InWindow:  return "InWindow";
-    case None:      return "None";
-    default:        META_UNEXPECTED_ENUM_ARG_RETURN(property_value, "Undefined");
-    }
-}
-
-std::string State::Property::ToString(State::Property::Mask properties_mask)
-{
-    META_FUNCTION_TASK();
-    std::stringstream ss;
-    bool first_property = true;
-    for (Value property_value : values)
-    {
-        if (!(properties_mask & property_value))
-            continue;
-
-        if (!first_property)
-        {
-            ss << g_properties_separator;
-        }
-        ss << ToString(property_value);
-        first_property = false;
-    }
-    return ss.str();
-}
 
 State::State(std::initializer_list<Button> pressed_buttons, const Position& position, const Scroll& scroll, bool in_window)
     : m_position(position)
@@ -135,22 +101,24 @@ bool State::operator==(const State& other) const
            m_in_window     == other.m_in_window;
 }
 
-State::Property::Mask State::GetDiff(const State& other) const
+State::Properties State::GetDiff(const State& other) const
 {
     META_FUNCTION_TASK();
-    State::Property::Mask properties_diff_mask = State::Property::None;
+    using namespace magic_enum::bitwise_operators;
+
+    State::Properties properties_diff_mask = State::Properties::None;
 
     if (m_button_states != other.m_button_states)
-        properties_diff_mask |= State::Property::Buttons;
+        properties_diff_mask |= State::Properties::Buttons;
     
     if (m_position != other.m_position)
-        properties_diff_mask |= State::Property::Position;
+        properties_diff_mask |= State::Properties::Position;
 
     if (m_scroll != other.m_scroll)
-        properties_diff_mask |= State::Property::Scroll;
+        properties_diff_mask |= State::Properties::Scroll;
 
     if (m_in_window != other.m_in_window)
-        properties_diff_mask |= State::Property::InWindow;
+        properties_diff_mask |= State::Properties::InWindow;
 
     return properties_diff_mask;
 }

--- a/Modules/Platform/Input/Sources/Methane/Platform/Mouse.cpp
+++ b/Modules/Platform/Input/Sources/Methane/Platform/Mouse.cpp
@@ -70,28 +70,6 @@ State::State(std::initializer_list<Button> pressed_buttons, const Position& posi
     }
 }
 
-State::State(const State& other)
-    : m_button_states(other.m_button_states)
-    , m_position(other.m_position)
-    , m_scroll(other.m_scroll)
-    , m_in_window(other.m_in_window)
-{
-    META_FUNCTION_TASK();
-}
-
-State& State::operator=(const State& other)
-{
-    META_FUNCTION_TASK();
-    if (this != &other)
-    {
-        m_button_states = other.m_button_states;
-        m_position      = other.m_position;
-        m_scroll        = other.m_scroll;
-        m_in_window     = other.m_in_window;
-    }
-    return *this;
-}
-
 bool State::operator==(const State& other) const
 {
     META_FUNCTION_TASK();

--- a/Modules/Platform/Input/Sources/Methane/Platform/Windows/Keyboard.cpp
+++ b/Modules/Platform/Input/Sources/Methane/Platform/Windows/Keyboard.cpp
@@ -185,7 +185,7 @@ Key KeyConverter::GetControlKey(const NativeKey& native_key)
     //       Right Alt we ignore this (synthetic) Left Ctrl message
     time = GetMessageTime();
 
-    if (!PeekMessageW(&next, 0, 0, 0, PM_NOREMOVE))
+    if (!PeekMessageW(&next, nullptr, 0, 0, PM_NOREMOVE))
         return Key::LeftControl;
 
     if ((next.message == WM_KEYDOWN || next.message == WM_SYSKEYDOWN || next.message == WM_KEYUP || next.message == WM_SYSKEYUP) &&

--- a/Modules/Platform/Input/Sources/Methane/Platform/Windows/Keyboard.cpp
+++ b/Modules/Platform/Input/Sources/Methane/Platform/Windows/Keyboard.cpp
@@ -158,49 +158,41 @@ Key KeyConverter::GetKeyByNativeCode(const NativeKey& native_key)
         { 0x04A, Key::KeyPadSubtract},
     };
 
-
     // The Ctrl keys require special handling
     if (native_key.w_param == VK_CONTROL)
-    {
-        MSG  next {};
-        LONG time = 0;
-
-        // Right side keys have the extended key bit set
-        if (native_key.l_param & 0x01000000)
-            return Key::Unknown;
-
-        // HACK: Alt Gr sends Left Ctrl and then Right Alt in close sequence
-        //       We only want the Right Alt message, so if the next message is
-        //       Right Alt we ignore this (synthetic) Left Ctrl message
-        time = GetMessageTime();
-
-        if (PeekMessageW(&next, NULL, 0, 0, PM_NOREMOVE))
-        {
-            if (next.message == WM_KEYDOWN ||
-                next.message == WM_SYSKEYDOWN ||
-                next.message == WM_KEYUP ||
-                next.message == WM_SYSKEYUP)
-            {
-                if (next.wParam == VK_MENU && (next.lParam & 0x01000000) && next.time == static_cast<DWORD>(time))
-                {
-                    // Next message is Right Alt down so discard this
-                    return Key::Unknown;
-                }
-            }
-        }
-
-        return Key::LeftControl;
-    }
+        return GetControlKey(native_key);
 
     if (native_key.w_param == VK_PROCESSKEY)
-    {
-        // IME notifies that keys have been filtered by setting the virtual key-code to VK_PROCESSKEY
-        return Key::Unknown;
-    }
+        return Key::Unknown; // IME notifies that keys have been filtered by setting the virtual key-code to VK_PROCESSKEY
 
     const uint32_t native_key_code = static_cast<uint32_t>(HIWORD(native_key.l_param) & 0x1FF);
     auto native_code_and_key_it = s_key_by_native_code.find(native_key_code);
-    return native_code_and_key_it == s_key_by_native_code.end() ? Key::Unknown : native_code_and_key_it->second;
+    return native_code_and_key_it == s_key_by_native_code.end()
+         ? Key::Unknown : native_code_and_key_it->second;
+}
+
+Key KeyConverter::GetControlKey(const NativeKey& native_key)
+{
+    MSG  next {};
+    LONG time = 0;
+
+    // Right side keys have the extended key bit set
+    if (native_key.l_param & 0x01000000)
+        return Key::Unknown;
+
+    // HACK: Alt Gr sends Left Ctrl and then Right Alt in close sequence
+    //       We only want the Right Alt message, so if the next message is
+    //       Right Alt we ignore this (synthetic) Left Ctrl message
+    time = GetMessageTime();
+
+    if (!PeekMessageW(&next, 0, 0, 0, PM_NOREMOVE))
+        return Key::LeftControl;
+
+    if ((next.message == WM_KEYDOWN || next.message == WM_SYSKEYDOWN || next.message == WM_KEYUP || next.message == WM_SYSKEYUP) &&
+        next.wParam == VK_MENU && (next.lParam & 0x01000000) && next.time == static_cast<DWORD>(time))
+        return Key::Unknown; // Next message is Right Alt down so discard this
+
+    return Key::LeftControl;
 }
 
 Modifiers KeyConverter::GetModifiersByNativeCode(const NativeKey& native_key)

--- a/Modules/Platform/Input/Sources/Methane/Platform/Windows/Keyboard.cpp
+++ b/Modules/Platform/Input/Sources/Methane/Platform/Windows/Keyboard.cpp
@@ -203,15 +203,15 @@ Key KeyConverter::GetKeyByNativeCode(const NativeKey& native_key)
     return native_code_and_key_it == s_key_by_native_code.end() ? Key::Unknown : native_code_and_key_it->second;
 }
 
-Modifier::Mask KeyConverter::GetModifiersByNativeCode(const NativeKey& native_key)
+Modifiers KeyConverter::GetModifiersByNativeCode(const NativeKey& native_key)
 {
     META_FUNCTION_TASK();
     switch (native_key.w_param)
     {
-    case VK_CONTROL: return Modifier::Value::Control;
-    case VK_SHIFT:   return Modifier::Value::Shift;
-    case VK_CAPITAL: return Modifier::Value::CapsLock;
-    default:         return Modifier::Value::None;
+    case VK_CONTROL: return Modifiers::Control;
+    case VK_SHIFT:   return Modifiers::Shift;
+    case VK_CAPITAL: return Modifiers::CapsLock;
+    default:         return Modifiers::None;
     }
 }
 

--- a/Modules/UserInterface/App/Include/Methane/UserInterface/App.h
+++ b/Modules/UserInterface/App/Include/Methane/UserInterface/App.h
@@ -52,10 +52,8 @@ struct IApp : Graphics::IApp
 
     virtual const IApp::Settings& GetUserInterfaceAppSettings() const noexcept = 0;
     virtual bool SetHeadsUpDisplayMode(HeadsUpDisplayMode heads_up_display_mode) = 0;
-
     virtual std::string GetParametersString() = 0;
 
-    virtual ~IApp() = default;
 };
 
 } // namespace Methane::UserInterface

--- a/Modules/UserInterface/App/Include/Methane/UserInterface/App.h
+++ b/Modules/UserInterface/App/Include/Methane/UserInterface/App.h
@@ -53,7 +53,6 @@ struct IApp : Graphics::IApp
     virtual const IApp::Settings& GetUserInterfaceAppSettings() const noexcept = 0;
     virtual bool SetHeadsUpDisplayMode(HeadsUpDisplayMode heads_up_display_mode) = 0;
     virtual std::string GetParametersString() = 0;
-
 };
 
 } // namespace Methane::UserInterface

--- a/Modules/UserInterface/App/Include/Methane/UserInterface/App.h
+++ b/Modules/UserInterface/App/Include/Methane/UserInterface/App.h
@@ -32,13 +32,11 @@ namespace Methane::UserInterface
 
 struct IApp : Graphics::IApp
 {
-    enum HeadsUpDisplayMode : uint32_t
+    enum class HeadsUpDisplayMode : uint32_t
     {
         Hidden = 0U,
         WindowTitle,
-        UserInterface,
-
-        Count
+        UserInterface
     };
 
     struct Settings

--- a/Modules/UserInterface/App/Include/Methane/UserInterface/AppController.h
+++ b/Modules/UserInterface/App/Include/Methane/UserInterface/AppController.h
@@ -32,11 +32,8 @@ namespace Methane::UserInterface
 
 enum class AppAction : uint32_t
 {
-    None = 0,
-
-    SwitchHeadsUpDisplayMode,
-
-    Count
+    None = 0U,
+    SwitchHeadsUpDisplayMode
 };
 
 class AppController

--- a/Modules/UserInterface/App/Sources/Methane/UserInterface/AppController.cpp
+++ b/Modules/UserInterface/App/Sources/Methane/UserInterface/AppController.cpp
@@ -26,6 +26,8 @@ Base user interface application controller
 #include <Methane/Instrumentation.h>
 #include <Methane/Checks.hpp>
 
+#include <magic_enum.hpp>
+
 namespace Methane::UserInterface
 {
 
@@ -54,7 +56,7 @@ void AppController::OnKeyboardStateAction(AppAction action)
     {
     case AppAction::SwitchHeadsUpDisplayMode:
         m_application.SetHeadsUpDisplayMode(static_cast<IApp::HeadsUpDisplayMode>(
-            (static_cast<uint32_t>(m_application.GetUserInterfaceAppSettings().heads_up_display_mode) + 1) % IApp::HeadsUpDisplayMode::Count));
+            (static_cast<uint32_t>(m_application.GetUserInterfaceAppSettings().heads_up_display_mode) + 1) % magic_enum::enum_count<IApp::HeadsUpDisplayMode>()));
         break;
 
     default:

--- a/Modules/UserInterface/App/Sources/Methane/UserInterface/AppController.cpp
+++ b/Modules/UserInterface/App/Sources/Methane/UserInterface/AppController.cpp
@@ -55,8 +55,8 @@ void AppController::OnKeyboardStateAction(AppAction action)
     switch(action)
     {
     case AppAction::SwitchHeadsUpDisplayMode:
-        m_application.SetHeadsUpDisplayMode(static_cast<IApp::HeadsUpDisplayMode>(
-            (static_cast<uint32_t>(m_application.GetUserInterfaceAppSettings().heads_up_display_mode) + 1) % magic_enum::enum_count<IApp::HeadsUpDisplayMode>()));
+        m_application.SetHeadsUpDisplayMode(magic_enum::enum_value<IApp::HeadsUpDisplayMode>(
+            (magic_enum::enum_integer(m_application.GetUserInterfaceAppSettings().heads_up_display_mode) + 1) % magic_enum::enum_count<IApp::HeadsUpDisplayMode>()));
         break;
 
     default:

--- a/Modules/UserInterface/Types/Include/Methane/UserInterface/Types.hpp
+++ b/Modules/UserInterface/Types/Include/Methane/UserInterface/Types.hpp
@@ -74,7 +74,7 @@ struct UnitType : BaseType
     UnitType(Units units, BaseType&& base) noexcept      : BaseType(std::move(base)), units(units) { }
 
     template<typename... BaseArgs>
-    UnitType(Units units, const BaseArgs&... base_args) noexcept : BaseType(base_args...), units(units) { }
+    UnitType(Units units, BaseArgs&&... base_args) noexcept : BaseType(std::forward<BaseArgs>(base_args)...), units(units) { }
 
     bool operator==(const UnitType& other) const noexcept                  { return BaseType::operator==(other) && units == other.units; }
     bool operator!=(const UnitType& other) const noexcept                  { return BaseType::operator!=(other) || units != other.units; }

--- a/Modules/UserInterface/Typography/CMakeLists.txt
+++ b/Modules/UserInterface/Typography/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(${TARGET}
         MethanePrecompiledExtraHeaders
         MethaneDataPrimitives
         freetype
+        magic_enum
 )
 
 target_precompile_headers(${TARGET} REUSE_FROM MethanePrecompiledExtraHeaders)

--- a/Modules/UserInterface/Typography/Include/Methane/UserInterface/Font.h
+++ b/Modules/UserInterface/Typography/Include/Methane/UserInterface/Font.h
@@ -135,28 +135,22 @@ public:
         class Glyph;
         using Code = char32_t;
 
-        struct Type
+        enum class Type : uint8_t
         {
-            using Mask = uint8_t;
-            enum Value : Mask
-            {
-                Unknown    = 0U,
-                Whitespace = 1U << 0U,
-                LineBreak  = 1U << 1U,
-            };
-
-            static Mask Get(Code code);
-
-            Type() = delete;
+            Unknown    = 0U,
+            Whitespace = 1U << 0U,
+            LineBreak  = 1U << 1U
         };
+
+        static Type GetType(Code code);
 
         Char() = default;
         explicit Char(Code code);
         Char(Code code, gfx::FrameRect rect, gfx::Point2i offset, gfx::Point2i advance, UniquePtr<Glyph>&& glyph_ptr);
 
         Code                  GetCode() const noexcept        { return m_code; }
-        bool                  IsLineBreak() const noexcept    { return m_type_mask & Type::LineBreak; }
-        bool                  IsWhiteSpace() const noexcept   { return m_type_mask & Type::Whitespace; }
+        bool                  IsLineBreak() const noexcept    { return static_cast<uint8_t>(m_type_mask) & static_cast<uint8_t>(Type::LineBreak); }
+        bool                  IsWhiteSpace() const noexcept   { return static_cast<uint8_t>(m_type_mask) & static_cast<uint8_t>(Type::Whitespace); }
         const gfx::FrameRect& GetRect() const noexcept        { return m_rect; }
         const gfx::Point2i&   GetOffset() const noexcept      { return m_offset; }
         const gfx::Point2i&   GetAdvance() const noexcept     { return m_advance; }
@@ -171,7 +165,7 @@ public:
 
     private:
         const Code       m_code = 0U;
-        const Type::Mask m_type_mask = Type::Value::Unknown;
+        const Type       m_type_mask = Type::Unknown;
         gfx::FrameRect   m_rect;
         gfx::Point2i     m_offset;
         gfx::Point2i     m_advance;

--- a/Modules/UserInterface/Typography/Include/Methane/UserInterface/Font.h
+++ b/Modules/UserInterface/Typography/Include/Methane/UserInterface/Font.h
@@ -214,7 +214,7 @@ protected:
     // IContextCallback interface
     void OnContextReleased(gfx::Context& context) override;
     void OnContextCompletingInitialization(gfx::Context& context) override;
-    void OnContextInitialized(gfx::Context&) override { }
+    void OnContextInitialized(gfx::Context&) override { /* callback not handled in this class */}
 
 private:
     struct AtlasTexture

--- a/Modules/UserInterface/Typography/Include/Methane/UserInterface/Text.h
+++ b/Modules/UserInterface/Typography/Include/Methane/UserInterface/Text.h
@@ -137,7 +137,7 @@ public:
 protected:
     // IFontCallback interface
     void OnFontAtlasTextureReset(Font& font, const Ptr<gfx::Texture>& old_atlas_texture_ptr, const Ptr<gfx::Texture>& new_atlas_texture_ptr) override;
-    void OnFontAtlasUpdated(Font&) override {}
+    void OnFontAtlasUpdated(Font&) override { /* not handled in this class */ }
 
 private:
     struct Constants;
@@ -146,26 +146,22 @@ private:
     class FrameResources
     {
     public:
-        struct Dirty
+        enum class DirtyFlags : uint32_t
         {
-            using Mask = uint32_t;
-            enum Value : Mask
-            {
-                None         = 0U,
-                Mesh         = 1U << 0U,
-                Uniforms     = 1U << 1U,
-                Atlas        = 1U << 2U,
-                All          = ~0U,
-            };
+            None     = 0U,
+            Mesh     = 1U << 0U,
+            Uniforms = 1U << 1U,
+            Atlas    = 1U << 2U,
+            All      = ~0U
         };
 
         FrameResources(gfx::RenderState& state, gfx::RenderContext& render_context,
                        const Ptr<gfx::Buffer>& const_buffer_ptr, const Ptr<gfx::Texture>& atlas_texture_ptr, const Ptr<gfx::Sampler>& atlas_sampler_ptr,
                        const TextMesh& text_mesh, const std::string& text_name, Data::Size reservation_multiplier);
 
-        void SetDirty(Dirty::Mask dirty_flags) noexcept         { m_dirty_mask |= dirty_flags; }
-        bool IsDirty() const noexcept                           { return m_dirty_mask != Dirty::None; }
-        bool IsDirty(Dirty::Mask dirty_flags) const noexcept    { return m_dirty_mask & dirty_flags; }
+        void SetDirty(DirtyFlags dirty_flags) noexcept;
+        bool IsDirty(DirtyFlags dirty_flags) const noexcept;
+        bool IsDirty() const noexcept                           { return m_dirty_mask != DirtyFlags::None; }
         bool IsInitialized() const noexcept                     { return m_program_bindings_ptr && m_vertex_buffer_set_ptr && m_index_buffer_ptr; }
         bool IsAtlasInitialized() const noexcept                { return !!m_atlas_texture_ptr; }
 
@@ -179,7 +175,7 @@ private:
         void InitializeProgramBindings(gfx::RenderState& state, const Ptr<gfx::Buffer>& const_buffer_ptr, const Ptr<gfx::Sampler>& atlas_sampler_ptr);
 
     private:
-        Dirty::Mask               m_dirty_mask = Dirty::None;
+        DirtyFlags               m_dirty_mask = DirtyFlags::None;
         Ptr<gfx::BufferSet>       m_vertex_buffer_set_ptr;
         Ptr<gfx::Buffer>          m_index_buffer_ptr;
         Ptr<gfx::Buffer>          m_uniforms_buffer_ptr;
@@ -188,7 +184,7 @@ private:
     };
 
     void InitializeFrameResources();
-    void MakeFrameResourcesDirty(FrameResources::Dirty::Mask dirty_flags);
+    void MakeFrameResourcesDirty(FrameResources::DirtyFlags dirty_flags);
     FrameResources& GetCurrentFrameResources();
 
     void UpdateTextMesh();

--- a/Modules/UserInterface/Typography/Include/Methane/UserInterface/Text.h
+++ b/Modules/UserInterface/Typography/Include/Methane/UserInterface/Text.h
@@ -130,10 +130,6 @@ public:
     void Update(const gfx::FrameSize& render_attachment_size);
     void Draw(gfx::RenderCommandList& cmd_list, gfx::CommandList::DebugGroup* p_debug_group = nullptr);
 
-    static std::string GetWrapName(Wrap wrap);
-    static std::string GetHorizontalAlignmentName(HorizontalAlignment alignment);
-    static std::string GetVerticalAlignmentName(VerticalAlignment alignment);
-
 protected:
     // IFontCallback interface
     void OnFontAtlasTextureReset(Font& font, const Ptr<gfx::Texture>& old_atlas_texture_ptr, const Ptr<gfx::Texture>& new_atlas_texture_ptr) override;

--- a/Modules/UserInterface/Typography/Include/Methane/UserInterface/Text.h
+++ b/Modules/UserInterface/Typography/Include/Methane/UserInterface/Text.h
@@ -107,7 +107,7 @@ public:
 
     Text(Context& ui_context, Font& font, const SettingsUtf8&  settings);
     Text(Context& ui_context, Font& font, SettingsUtf32 settings);
-    ~Text();
+    ~Text() override;
 
     const SettingsUtf32&  GetSettings() const noexcept            { return m_settings; }
     const std::u32string& GetTextUtf32() const noexcept           { return m_settings.text; }

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
@@ -30,6 +30,7 @@ Font atlas textures generation and fonts library management classes.
 #include <Methane/Checks.hpp>
 
 #include <nowide/convert.hpp>
+#include <magic_enum.hpp>
 #include <map>
 #include <set>
 #include <locale>
@@ -781,9 +782,12 @@ void Font::OnContextCompletingInitialization(gfx::Context& context)
 
 static constexpr Font::Char::Code g_line_break_code = static_cast<Font::Char::Code>('\n');
 
-Font::Char::Type::Mask Font::Char::Type::Get(Font::Char::Code char_code)
+Font::Char::Type Font::Char::GetType(Font::Char::Code char_code)
 {
-    Font::Char::Type::Mask type_mask = Font::Char::Type::Unknown;
+    META_FUNCTION_TASK();
+    using namespace magic_enum::bitwise_operators;
+
+    Font::Char::Type type_mask = Font::Char::Type::Unknown;
     if (char_code > 255)
         return type_mask;
 
@@ -798,14 +802,14 @@ Font::Char::Type::Mask Font::Char::Type::Get(Font::Char::Code char_code)
 
 Font::Char::Char(Code code)
     : m_code(code)
-    , m_type_mask(Type::Get(code))
+    , m_type_mask(GetType(code))
 {
     META_FUNCTION_TASK();
 }
 
 Font::Char::Char(Code code, gfx::FrameRect rect, gfx::Point2i offset, gfx::Point2i advance, UniquePtr<Glyph>&& glyph_ptr)
     : m_code(code)
-    , m_type_mask(Type::Get(code))
+    , m_type_mask(GetType(code))
     , m_rect(std::move(rect))
     , m_offset(std::move(offset))
     , m_advance(std::move(advance))

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
@@ -700,40 +700,4 @@ void Text::UpdateViewport(const gfx::FrameSize& render_attachment_size)
     m_is_viewport_dirty = false;
 }
 
-std::string Text::GetWrapName(Wrap wrap)
-{
-    META_FUNCTION_TASK();
-    switch (wrap)
-    {
-    case Wrap::None:     return "No Wrap";
-    case Wrap::Anywhere: return "Wrap Anywhere";
-    case Wrap::Word:     return "Wrap Words";
-    default:             META_UNEXPECTED_ENUM_ARG_RETURN(wrap, "Undefined Wrap");
-    }
-}
-
-std::string Text::GetHorizontalAlignmentName(HorizontalAlignment alignment)
-{
-    META_FUNCTION_TASK();
-    switch(alignment)
-    {
-    case HorizontalAlignment::Left:   return "Left";
-    case HorizontalAlignment::Right:  return "Right";
-    case HorizontalAlignment::Center: return "Center";
-    default:                          META_UNEXPECTED_ENUM_ARG_RETURN(alignment, "undefined horizontal alignment");
-    }
-}
-
-std::string Text::GetVerticalAlignmentName(VerticalAlignment alignment)
-{
-    META_FUNCTION_TASK();
-    switch(alignment)
-    {
-    case VerticalAlignment::Top:    return "Top";
-    case VerticalAlignment::Bottom: return "Bottom";
-    case VerticalAlignment::Center: return "Center";
-    default:                        META_UNEXPECTED_ENUM_ARG_RETURN(alignment, "undefined vertical alignment");
-    }
-}
-
 } // namespace Methane::Graphics

--- a/Modules/UserInterface/Widgets/Include/Methane/UserInterface/HeadsUpDisplay.h
+++ b/Modules/UserInterface/Widgets/Include/Methane/UserInterface/HeadsUpDisplay.h
@@ -71,10 +71,7 @@ public:
     void Draw(gfx::RenderCommandList& cmd_list, gfx::CommandList::DebugGroup* p_debug_group = nullptr);
 
 private:
-    void LayoutTextBlocks();
-    void UpdateAllTextBlocks(const FrameSize& render_attachment_size);
-
-    enum TextBlock : size_t
+    enum class TextBlock : size_t
     {
         Fps = 0U,
         FrameTime,
@@ -82,12 +79,14 @@ private:
         GpuName,
         HelpKey,
         FrameBuffers,
-        VSync,
-
-        Count
+        VSync
     };
 
-    using TextBlockPtrs = std::array<Ptr<Text>, TextBlock::Count>;
+    using TextBlockPtrs = std::array<Ptr<Text>, 7>;
+    Text& GetTextBlock(TextBlock block) const;
+
+    void LayoutTextBlocks();
+    void UpdateAllTextBlocks(const FrameSize& render_attachment_size);
 
     Settings            m_settings;
     const Ptr<Font>     m_major_font_ptr;

--- a/Modules/UserInterface/Widgets/Include/Methane/UserInterface/HeadsUpDisplay.h
+++ b/Modules/UserInterface/Widgets/Include/Methane/UserInterface/HeadsUpDisplay.h
@@ -32,6 +32,8 @@ Heads-Up-Display widget for displaying runtime rendering parameters.
 #include <Methane/Timer.hpp>
 #include <Methane/Memory.hpp>
 
+#include <magic_enum.hpp>
+
 namespace Methane::Graphics
 {
 struct RenderCommandList;
@@ -82,7 +84,7 @@ private:
         VSync
     };
 
-    using TextBlockPtrs = std::array<Ptr<Text>, 7>;
+    using TextBlockPtrs = std::array<Ptr<Text>, magic_enum::enum_count<TextBlock>()>;
     Text& GetTextBlock(TextBlock block) const;
 
     void LayoutTextBlocks();

--- a/Modules/UserInterface/Widgets/Include/Methane/UserInterface/HeadsUpDisplay.h
+++ b/Modules/UserInterface/Widgets/Include/Methane/UserInterface/HeadsUpDisplay.h
@@ -60,7 +60,7 @@ public:
         double                    update_interval_sec = 0.33;
     };
 
-    HeadsUpDisplay(Context& ui_context, const Data::Provider& font_data_provider, Settings settings);
+    HeadsUpDisplay(Context& ui_context, const Data::Provider& font_data_provider, const Settings& settings);
 
     const Settings& GetSettings() const { return m_settings; }
 

--- a/Modules/UserInterface/Widgets/Sources/Methane/UserInterface/HeadsUpDisplay.cpp
+++ b/Modules/UserInterface/Widgets/Sources/Methane/UserInterface/HeadsUpDisplay.cpp
@@ -53,12 +53,12 @@ inline uint32_t GetTextHeightInDots(const Context& ui_context, const Font& font)
     return ui_context.ConvertPixelsToDots(font.GetMaxGlyphSize().height);
 }
 
-inline uint32_t GetFpsTextHeightInDots(Context& ui_context, Font& major_font, Font& minor_font, const UnitSize& text_margins)
+inline uint32_t GetFpsTextHeightInDots(const Context& ui_context, const Font& major_font, const Font& minor_font, const UnitSize& text_margins)
 {
     return std::max(GetTextHeightInDots(ui_context, major_font), GetTextHeightInDots(ui_context, minor_font) * 2U + ui_context.ConvertToDots(text_margins).height);
 }
 
-inline uint32_t GetTimingTextHeightInDots(Context& ui_context, Font& major_font, Font& minor_font, const UnitSize& text_margins)
+inline uint32_t GetTimingTextHeightInDots(const Context& ui_context, const Font& major_font, const Font& minor_font, const UnitSize& text_margins)
 {
     return (GetFpsTextHeightInDots(ui_context, major_font, minor_font, text_margins) - ui_context.ConvertToDots(text_margins).height) / 2U;
 }

--- a/Modules/UserInterface/Widgets/Sources/Methane/UserInterface/HeadsUpDisplay.cpp
+++ b/Modules/UserInterface/Widgets/Sources/Methane/UserInterface/HeadsUpDisplay.cpp
@@ -48,7 +48,7 @@ namespace Methane::UserInterface
 
 static constexpr uint32_t g_first_line_height_decrement = 5;
 
-inline uint32_t GetTextHeightInDots(Context& ui_context, Font& font)
+inline uint32_t GetTextHeightInDots(const Context& ui_context, const Font& font)
 {
     return ui_context.ConvertPixelsToDots(font.GetMaxGlyphSize().height);
 }
@@ -63,9 +63,9 @@ inline uint32_t GetTimingTextHeightInDots(Context& ui_context, Font& major_font,
     return (GetFpsTextHeightInDots(ui_context, major_font, minor_font, text_margins) - ui_context.ConvertToDots(text_margins).height) / 2U;
 }
 
-HeadsUpDisplay::HeadsUpDisplay(Context& ui_context, const Data::Provider& font_data_provider, Settings settings)
+HeadsUpDisplay::HeadsUpDisplay(Context& ui_context, const Data::Provider& font_data_provider, const Settings& settings)
     : Panel(ui_context, { }, { "Heads Up Display" })
-    , m_settings(std::move(settings))
+    , m_settings(settings)
     , m_major_font_ptr(
         Font::Library::Get().GetFont(font_data_provider,
             Font::Settings

--- a/Tests/Platform/Input/CMakeLists.txt
+++ b/Tests/Platform/Input/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(${TARGET}
         MethanePrecompiledHeaders
         $<$<BOOL:${METHANE_TRACY_PROFILING_ENABLED}>:TracyClient>
         Catch2
+        magic_enum
 )
 
 if (METHANE_RUN_TESTS_DURING_BUILD)

--- a/Tests/Platform/Input/KeyboardTest.cpp
+++ b/Tests/Platform/Input/KeyboardTest.cpp
@@ -25,7 +25,10 @@ Unit tests of the Keyboard data types
 
 #include <Methane/Platform/Keyboard.h>
 
+#include <magic_enum.hpp>
+
 using namespace Methane::Platform::Keyboard;
+using namespace magic_enum::bitwise_operators;
 
 TEST_CASE("Keyboard state initialization", "[keyboard-state]")
 {
@@ -35,14 +38,14 @@ TEST_CASE("Keyboard state initialization", "[keyboard-state]")
         const KeyStates released_key_states{};
         CHECK(keyboard_state.GetKeyStates() == released_key_states);
         CHECK(keyboard_state.GetPressedKeys() == Keys{});
-        CHECK(keyboard_state.GetModifiersMask() == Modifier::None);
+        CHECK(keyboard_state.GetModifiersMask() == Modifiers::None);
     }
 
     SECTION("Initializer list constructor")
     {
         const State keyboard_state{ Key::LeftControl, Key::LeftShift, Key::C };
         CHECK(keyboard_state.GetPressedKeys() == Keys{ Key::C });
-        CHECK(keyboard_state.GetModifiersMask() == (Modifier::Control | Modifier::Shift));
+        CHECK(keyboard_state.GetModifiersMask() == (Modifiers::Control | Modifiers::Shift));
     }
 
     SECTION("Copy constructor")
@@ -50,14 +53,14 @@ TEST_CASE("Keyboard state initialization", "[keyboard-state]")
         const State keyboard_state_a{ Key::LeftControl, Key::LeftShift, Key::C, Key::Up };
         const State keyboard_state_b(keyboard_state_a);
         CHECK(keyboard_state_b.GetPressedKeys() == Keys{ Key::C, Key::Up });
-        CHECK(keyboard_state_b.GetModifiersMask() == (Modifier::Control | Modifier::Shift));
+        CHECK(keyboard_state_b.GetModifiersMask() == (Modifiers::Control | Modifiers::Shift));
     }
     
     SECTION("Construct with unknown key")
     {
         const State keyboard_state{ Key::Unknown };
         CHECK(keyboard_state.GetPressedKeys() == Keys{ });
-        CHECK(keyboard_state.GetModifiersMask() == Modifier::None);
+        CHECK(keyboard_state.GetModifiersMask() == Modifiers::None);
     }
 }
 
@@ -68,7 +71,7 @@ TEST_CASE("Keyboard state modification", "[keyboard-state]")
         State keyboard_state;
         keyboard_state.PressKey(Key::A);
         CHECK(keyboard_state.GetPressedKeys() == Keys{ Key::A });
-        CHECK(keyboard_state.GetModifiersMask() == Modifier::None);
+        CHECK(keyboard_state.GetModifiersMask() == Modifiers::None);
     }
 
     SECTION("Press control key")
@@ -76,7 +79,7 @@ TEST_CASE("Keyboard state modification", "[keyboard-state]")
         State keyboard_state;
         keyboard_state.PressKey(Key::LeftAlt);
         CHECK(keyboard_state.GetPressedKeys() == Keys{ });
-        CHECK(keyboard_state.GetModifiersMask() == Modifier::Alt);
+        CHECK(keyboard_state.GetModifiersMask() == Modifiers::Alt);
     }
 
     SECTION("Release printable key")
@@ -84,7 +87,7 @@ TEST_CASE("Keyboard state modification", "[keyboard-state]")
         State keyboard_state{ Key::RightControl, Key::RightAlt, Key::W, Key::Num3 };
         keyboard_state.ReleaseKey(Key::Num3);
         CHECK(keyboard_state.GetPressedKeys() == Keys{ Key::W });
-        CHECK(keyboard_state.GetModifiersMask() == (Modifier::Control | Modifier::Alt));
+        CHECK(keyboard_state.GetModifiersMask() == (Modifiers::Control | Modifiers::Alt));
     }
 
     SECTION("Release control key")
@@ -92,7 +95,7 @@ TEST_CASE("Keyboard state modification", "[keyboard-state]")
         State keyboard_state{ Key::RightControl, Key::RightAlt, Key::W, Key::Num3 };
         keyboard_state.ReleaseKey(Key::RightAlt);
         CHECK(keyboard_state.GetPressedKeys() == Keys{ Key::W, Key::Num3 });
-        CHECK(keyboard_state.GetModifiersMask() == Modifier::Control);
+        CHECK(keyboard_state.GetModifiersMask() == Modifiers::Control);
     }
 }
 
@@ -103,7 +106,7 @@ TEST_CASE("Keyboard state comparison", "[keyboard-state]")
         const State keyboard_state_a{ Key::RightControl, Key::LeftAlt,  Key::Up, Key::Y, Key::Num5 };
         const State keyboard_state_b{ Key::LeftControl,  Key::RightAlt, Key::Up, Key::Y, Key::Num5 };
         CHECK(keyboard_state_a == keyboard_state_b);
-        CHECK(keyboard_state_a.GetDiff(keyboard_state_b) == State::Property::None);
+        CHECK(keyboard_state_a.GetDiff(keyboard_state_b) == State::Properties::None);
     }
 
     SECTION("States inequality in printable keys")
@@ -111,7 +114,7 @@ TEST_CASE("Keyboard state comparison", "[keyboard-state]")
         const State keyboard_state_a{ Key::RightControl, Key::LeftAlt,   Key::Down, Key::U, Key::Num2 };
         const State keyboard_state_b{ Key::LeftControl,  Key::RightAlt,  Key::Up,   Key::Y, Key::Num5 };
         CHECK(keyboard_state_a != keyboard_state_b);
-        CHECK(keyboard_state_a.GetDiff(keyboard_state_b) == State::Property::KeyStates);
+        CHECK(keyboard_state_a.GetDiff(keyboard_state_b) == State::Properties::KeyStates);
     }
 
     SECTION("States inequality in modifiers")
@@ -119,6 +122,6 @@ TEST_CASE("Keyboard state comparison", "[keyboard-state]")
         const State keyboard_state_a{ Key::RightControl, Key::LeftShift, Key::Up, Key::Y, Key::Num5 };
         const State keyboard_state_b{ Key::LeftControl,  Key::RightAlt,  Key::Up, Key::Y, Key::Num5 };
         CHECK(keyboard_state_a != keyboard_state_b);
-        CHECK(keyboard_state_a.GetDiff(keyboard_state_b) == State::Property::Modifiers);
+        CHECK(keyboard_state_a.GetDiff(keyboard_state_b) == State::Properties::Modifiers);
     }
 }

--- a/Tests/Platform/Input/MouseTest.cpp
+++ b/Tests/Platform/Input/MouseTest.cpp
@@ -120,7 +120,7 @@ TEST_CASE("Mouse state comparison", "[mouse-state]")
         const State mouse_state_a({ Button::Left }, g_test_position, g_test_scroll, true);
         const State mouse_state_b({ Button::Left }, g_test_position, g_test_scroll, true);
         CHECK(mouse_state_a == mouse_state_b);
-        CHECK(mouse_state_a.GetDiff(mouse_state_b) == State::Property::None);
+        CHECK(mouse_state_a.GetDiff(mouse_state_b) == State::Properties::None);
     }
 
     SECTION("States inequality in buttons")
@@ -128,7 +128,7 @@ TEST_CASE("Mouse state comparison", "[mouse-state]")
         const State mouse_state_a({ Button::Left },  g_test_position, g_test_scroll, true);
         const State mouse_state_b({ Button::Right }, g_test_position, g_test_scroll, true);
         CHECK(mouse_state_a != mouse_state_b);
-        CHECK(mouse_state_a.GetDiff(mouse_state_b) == State::Property::Buttons);
+        CHECK(mouse_state_a.GetDiff(mouse_state_b) == State::Properties::Buttons);
     }
 
     SECTION("States inequality in position")
@@ -136,7 +136,7 @@ TEST_CASE("Mouse state comparison", "[mouse-state]")
         const State mouse_state_a({ Button::Left }, g_test_position, g_test_scroll, true);
         const State mouse_state_b({ Button::Left }, { 56, 78 }, g_test_scroll, true);
         CHECK(mouse_state_a != mouse_state_b);
-        CHECK(mouse_state_a.GetDiff(mouse_state_b) == State::Property::Position);
+        CHECK(mouse_state_a.GetDiff(mouse_state_b) == State::Properties::Position);
     }
 
     SECTION("States inequality in scroll")
@@ -144,7 +144,7 @@ TEST_CASE("Mouse state comparison", "[mouse-state]")
         const State mouse_state_a({ Button::Left }, g_test_position, g_test_scroll, true);
         const State mouse_state_b({ Button::Left }, g_test_position, { 4.f, 5.f }, true);
         CHECK(mouse_state_a != mouse_state_b);
-        CHECK(mouse_state_a.GetDiff(mouse_state_b) == State::Property::Scroll);
+        CHECK(mouse_state_a.GetDiff(mouse_state_b) == State::Properties::Scroll);
     }
 
     SECTION("States inequality in window")
@@ -152,6 +152,6 @@ TEST_CASE("Mouse state comparison", "[mouse-state]")
         const State mouse_state_a({ Button::Left }, g_test_position, g_test_scroll, true);
         const State mouse_state_b({ Button::Left }, g_test_position, g_test_scroll, false);
         CHECK(mouse_state_a != mouse_state_b);
-        CHECK(mouse_state_a.GetDiff(mouse_state_b) == State::Property::InWindow);
+        CHECK(mouse_state_a.GetDiff(mouse_state_b) == State::Properties::InWindow);
     }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -259,7 +259,7 @@ jobs:
                 mv default.profraw "$test_exe$prof_raw_ext"
                 xcrun llvm-profdata merge -o "$test_exe$prof_data_ext" "$test_exe$prof_raw_ext"
                 xcrun llvm-cov export -format lcov -instr-profile="$test_exe$prof_data_ext" ./$test_exe > "./Coverage/$test_exe$lcov_ext"
-                echo  - Converted code coverage from "$test_exe$prof_raw_ext" to lcov text format "./Coverage/$test_exe$lcov_ext", $? exit status
+                echo    - Converted code coverage from "$test_exe$prof_raw_ext" to lcov text format "./Coverage/$test_exe$lcov_ext", $? exit status
               done
               echo List of generated coverage files in directory $PWD/Coverage
               ls -la ./Coverage
@@ -269,7 +269,7 @@ jobs:
 - job: Ubuntu
 
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
 
   variables:
     platform: 'Ubuntu'
@@ -288,7 +288,7 @@ jobs:
 - job: Ubuntu_Sonar_Scan
 
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
 
   variables:
     platform: 'Ubuntu'


### PR DESCRIPTION
Use `magic_enum` library to replace raw `enum` types of bitmasks to `enum class` types, use enum names and counts generated in compile time.