### PR TITLE
Version 0.5: Fix new C++17 static analysis issues

### DIFF
--- a/Apps/Common/Include/Methane/Samples/AppSettings.hpp
+++ b/Apps/Common/Include/Methane/Samples/AppSettings.hpp
@@ -36,7 +36,7 @@ constexpr bool g_is_apple = true;
 constexpr bool g_is_apple = false;
 #endif
 
-inline Graphics::AppSettings GetGraphicsAppSettings(const std::string& app_name, bool animations_enabled = true, bool depth_enabled = true, float clear_depth = 1.F,
+[[nodiscard]] inline Graphics::AppSettings GetGraphicsAppSettings(const std::string& app_name, bool animations_enabled = true, bool depth_enabled = true, float clear_depth = 1.F,
                                                     std::optional<Graphics::Color4f> clear_color = Graphics::Color4f(0.0F, 0.2F, 0.4F, 1.0F))
 {
     using namespace magic_enum::bitwise_operators;

--- a/Apps/Common/Include/Methane/Samples/AppSettings.hpp
+++ b/Apps/Common/Include/Methane/Samples/AppSettings.hpp
@@ -30,18 +30,23 @@ Common application settings for Methane samples and tutorials.
 namespace Methane::Samples
 {
 
-#ifdef __APPLE__
-constexpr bool g_is_apple = true;
-#else
-constexpr bool g_is_apple = false;
-#endif
-
-[[nodiscard]] inline Graphics::AppSettings GetGraphicsAppSettings(const std::string& app_name, bool animations_enabled = true, bool depth_enabled = true, float clear_depth = 1.F,
-                                                    std::optional<Graphics::Color4f> clear_color = Graphics::Color4f(0.0F, 0.2F, 0.4F, 1.0F))
+[[nodiscard]] inline Graphics::AppSettings GetGraphicsAppSettings(
+                                                const std::string& app_name,
+                                                bool animations_enabled = true,
+                                                bool depth_enabled = true,
+                                                float clear_depth = 1.F,
+                                                std::optional<Graphics::Color4f> clear_color = Graphics::Color4f(0.0F, 0.2F, 0.4F, 1.0F))
 {
     using namespace magic_enum::bitwise_operators;
     using Stencil = Graphics::Stencil;
     using DepthStencilOpt = std::optional<Graphics::DepthStencil>;
+
+#ifdef __APPLE__
+    constexpr bool is_apple = true;
+#else
+    constexpr bool is_apple = false;
+#endif
+
     return Graphics::AppSettings
     {                                                               // =========================
         Platform::App::Settings {                                   // platform_app:
@@ -67,7 +72,7 @@ constexpr bool g_is_apple = false;
                 ? DepthStencilOpt({ clear_depth, Stencil(0) })      //     ...
                 : DepthStencilOpt(),                                //     ...
             3U,                                                     //   - frame_buffers_count
-            g_is_apple,                                             //   - vsync_enabled
+            is_apple,                                             //   - vsync_enabled
             false,                                                  //   - is_full_screen
             false,                                                  //   - is_emulated_render_pass
             1000U,                                                  //   - unsync_max_fps (MacOS only)

--- a/Apps/Samples/Asteroids/Asteroid.cpp
+++ b/Apps/Samples/Asteroids/Asteroid.cpp
@@ -252,10 +252,10 @@ void Asteroid::FillPerlinNoiseToTexture(Data::Bytes& texture_data, const gfx::Di
             const gfx::Vector3f noise_coordinates(noise_scale * static_cast<float>(row), noise_scale * static_cast<float>(col), random_seed);
             const float         noise_intensity = std::max(0.0F, std::min(1.0F, (perlin_noise(noise_coordinates) - 0.5F) * noise_strength + 0.5F));
 
-            auto texel_data = reinterpret_cast<uint8_t*>(&row_data[col]);
+            auto texel_data = reinterpret_cast<std::byte*>(&row_data[col]);
             for (size_t channel = 0; channel < 3; ++channel)
             {
-                texel_data[channel] = static_cast<uint8_t>(255.F * noise_intensity);
+                texel_data[channel] = static_cast<std::byte>(255.F * noise_intensity);
             }
         }
     }

--- a/Apps/Samples/Asteroids/Asteroid.cpp
+++ b/Apps/Samples/Asteroids/Asteroid.cpp
@@ -137,7 +137,7 @@ gfx::Resource::SubResources Asteroid::GenerateTextureArraySubresources(const gfx
 
     for (uint32_t array_index = 0; array_index < array_size; ++array_index)
     {
-        Data::Bytes sub_resource_data(pixels_count * pixel_size, 255U);
+        Data::Bytes sub_resource_data(pixels_count * pixel_size, std::byte(255));
         FillPerlinNoiseToTexture(sub_resource_data, dimensions, row_stride,
                                  noise_seed_distribution(rng),
                                  noise_parameters.persistence,

--- a/Apps/Samples/Asteroids/Asteroid.h
+++ b/Apps/Samples/Asteroids/Asteroid.h
@@ -65,7 +65,7 @@ public:
 
         void Randomize(uint32_t random_seed = 1337);
 
-        const gfx::Vector2f& GetDepthRange() const { return m_depth_range; }
+        [[nodiscard]] const gfx::Vector2f& GetDepthRange() const { return m_depth_range; }
 
     private:
         gfx::Vector2f m_depth_range;

--- a/Apps/Samples/Asteroids/AsteroidsApp.cpp
+++ b/Apps/Samples/Asteroids/AsteroidsApp.cpp
@@ -60,6 +60,7 @@ static const std::array<MutableParameters, g_max_complexity+1> g_mutable_paramet
     { 50000U, 1000U, 50U, 0.17F }, // 9
 } };
 
+[[nodiscard]]
 inline uint32_t GetDefaultComplexity()
 {
 #ifdef _DEBUG

--- a/Apps/Samples/Asteroids/AsteroidsApp.cpp
+++ b/Apps/Samples/Asteroids/AsteroidsApp.cpp
@@ -70,11 +70,13 @@ inline uint32_t GetDefaultComplexity()
 #endif
 }
 
+[[nodiscard]]
 inline const MutableParameters& GetMutableParameters(uint32_t complexity)
 {
     return g_mutable_parameters[std::min(complexity, g_max_complexity)];
 }
 
+[[nodiscard]]
 inline const MutableParameters& GetMutableParameters()
 {
     return GetMutableParameters(GetDefaultComplexity());

--- a/Apps/Samples/Asteroids/AsteroidsApp.cpp
+++ b/Apps/Samples/Asteroids/AsteroidsApp.cpp
@@ -152,15 +152,16 @@ AsteroidsApp::AsteroidsApp()
     const std::string options_group = "Asteroids Options";
     add_option_group(options_group);
     add_option("-c,--complexity",
-               [this](const CLI::results_t& res) {
-                       uint32_t complexity = 0;
-                       if (CLI::detail::lexical_cast(res[0], complexity))
-                       {
-                           SetAsteroidsComplexity(complexity);
-                           return true;
-                       }
-                       return false;
-                   }, "simulation complexity", true)
+               [this](const CLI::results_t& res)
+               {
+                   if (uint32_t complexity = 0;
+                       CLI::detail::lexical_cast(res[0], complexity))
+                   {
+                       SetAsteroidsComplexity(complexity);
+                       return true;
+                   }
+                   return false;
+               }, "simulation complexity", true)
         ->default_val(m_asteroids_complexity)
         ->expected(0, static_cast<int>(g_max_complexity))
         ->group(options_group);

--- a/Apps/Samples/Asteroids/AsteroidsArray.cpp
+++ b/Apps/Samples/Asteroids/AsteroidsArray.cpp
@@ -372,7 +372,7 @@ void AsteroidsArray::Draw(gfx::RenderCommandList &cmd_list, const gfx::MeshBuffe
     META_CHECK_ARG_GREATER_OR_EQUAL(buffer_bindings.uniforms_buffer_ptr->GetDataSize(), GetUniformsBufferSize());
     buffer_bindings.uniforms_buffer_ptr->SetData(GetFinalPassUniformsSubresources());
 
-    cmd_list.ResetWithState(m_render_state_ptr, s_debug_group.get());
+    cmd_list.ResetWithState(*m_render_state_ptr, s_debug_group.get());
     cmd_list.SetViewState(view_state);
 
     META_CHECK_ARG_EQUAL(buffer_bindings.program_bindings_per_instance.size(), m_settings.instance_count);
@@ -390,7 +390,7 @@ void AsteroidsArray::DrawParallel(gfx::ParallelRenderCommandList& parallel_cmd_l
     META_CHECK_ARG_GREATER_OR_EQUAL(buffer_bindings.uniforms_buffer_ptr->GetDataSize(), GetUniformsBufferSize());
     buffer_bindings.uniforms_buffer_ptr->SetData(GetFinalPassUniformsSubresources());
 
-    parallel_cmd_list.ResetWithState(m_render_state_ptr, s_debug_group.get());
+    parallel_cmd_list.ResetWithState(*m_render_state_ptr, s_debug_group.get());
     parallel_cmd_list.SetViewState(view_state);
 
     META_CHECK_ARG_EQUAL(buffer_bindings.program_bindings_per_instance.size(), m_settings.instance_count);

--- a/Apps/Samples/Asteroids/AsteroidsArray.cpp
+++ b/Apps/Samples/Asteroids/AsteroidsArray.cpp
@@ -71,7 +71,7 @@ AsteroidsArray::UberMesh::UberMesh(tf::Executor& parallel_executor, uint32_t ins
             [this, &rng, &data_mutex, &base_mesh](const int)
             {
                 Asteroid::Mesh asteroid_mesh(base_mesh);
-                asteroid_mesh.Randomize(rng());
+                asteroid_mesh.Randomize(rng()); // NOSONAR
 
                 std::lock_guard<LockableBase(std::mutex)> lock_guard(data_mutex);
                 m_depth_ranges.emplace_back(asteroid_mesh.GetDepthRange());

--- a/Apps/Samples/Asteroids/AsteroidsArray.cpp
+++ b/Apps/Samples/Asteroids/AsteroidsArray.cpp
@@ -73,7 +73,7 @@ AsteroidsArray::UberMesh::UberMesh(tf::Executor& parallel_executor, uint32_t ins
                 Asteroid::Mesh asteroid_mesh(base_mesh);
                 asteroid_mesh.Randomize(rng()); // NOSONAR
 
-                std::lock_guard<LockableBase(std::mutex)> lock_guard(data_mutex);
+                std::scoped_lock<LockableBase(std::mutex)> lock_guard(data_mutex);
                 m_depth_ranges.emplace_back(asteroid_mesh.GetDepthRange());
                 AddSubMesh(asteroid_mesh, false);
             },

--- a/Apps/Samples/Asteroids/AsteroidsArray.h
+++ b/Apps/Samples/Asteroids/AsteroidsArray.h
@@ -68,12 +68,12 @@ public:
     public:
         UberMesh(tf::Executor& parallel_executor, uint32_t instance_count, uint32_t subdivisions_count, uint32_t random_seed);
 
-        uint32_t GetInstanceCount() const noexcept      { return m_instance_count; }
-        uint32_t GetSubdivisionsCount() const noexcept  { return m_subdivisions_count; }
+        [[nodiscard]] uint32_t GetInstanceCount() const noexcept      { return m_instance_count; }
+        [[nodiscard]] uint32_t GetSubdivisionsCount() const noexcept  { return m_subdivisions_count; }
 
-        uint32_t             GetSubsetIndex(uint32_t instance_index, uint32_t subdivision_index) const;
-        uint32_t             GetSubsetSubdivision(uint32_t subset_index) const;
-        const gfx::Vector2f& GetSubsetDepthRange(uint32_t subset_index) const;
+        [[nodiscard]] uint32_t             GetSubsetIndex(uint32_t instance_index, uint32_t subdivision_index) const;
+        [[nodiscard]] uint32_t             GetSubsetSubdivision(uint32_t subset_index) const;
+        [[nodiscard]] const gfx::Vector2f& GetSubsetDepthRange(uint32_t subset_index) const;
 
     private:
         const uint32_t             m_instance_count;
@@ -99,8 +99,8 @@ public:
     AsteroidsArray(gfx::RenderContext& context, const Settings& settings);
     AsteroidsArray(gfx::RenderContext& context, const Settings& settings, ContentState& state);
 
-    const Settings& GetSettings() const         { return m_settings; }
-    const Ptr<ContentState>& GetState() const   { return m_content_state_ptr; }
+    [[nodiscard]] const Settings& GetSettings() const         { return m_settings; }
+    [[nodiscard]] const Ptr<ContentState>& GetState() const   { return m_content_state_ptr; }
     using BaseBuffers::GetUniformsBufferSize;
 
     Ptrs<gfx::ProgramBindings> CreateProgramBindings(const Ptr<gfx::Buffer>& constants_buffer_ptr,
@@ -111,11 +111,11 @@ public:
     void Draw(gfx::RenderCommandList& cmd_list, const gfx::MeshBufferBindings& buffer_bindings, gfx::ViewState& view_state);
     void DrawParallel(gfx::ParallelRenderCommandList& parallel_cmd_list, const gfx::MeshBufferBindings& buffer_bindings, gfx::ViewState& view_state);
 
-    bool  IsMeshLodColoringEnabled() const                           { return m_mesh_lod_coloring_enabled; }
-    void  SetMeshLodColoringEnabled(bool mesh_lod_coloring_enabled)  { m_mesh_lod_coloring_enabled = mesh_lod_coloring_enabled; }
+    [[nodiscard]] bool IsMeshLodColoringEnabled() const             { return m_mesh_lod_coloring_enabled; }
+    void SetMeshLodColoringEnabled(bool mesh_lod_coloring_enabled)  { m_mesh_lod_coloring_enabled = mesh_lod_coloring_enabled; }
 
-    float GetMinMeshLodScreenSize() const;
-    void  SetMinMeshLodScreenSize(float mesh_lod_min_screen_size);
+    [[nodiscard]] float GetMinMeshLodScreenSize() const;
+    void SetMinMeshLodScreenSize(float mesh_lod_min_screen_size);
 
 protected:
     // MeshBuffers overrides

--- a/Apps/Samples/Asteroids/Planet.cpp
+++ b/Apps/Samples/Asteroids/Planet.cpp
@@ -139,7 +139,7 @@ void Planet::Draw(gfx::RenderCommandList& cmd_list, gfx::MeshBufferBindings& buf
     META_CHECK_ARG_GREATER_OR_EQUAL(buffer_bindings.uniforms_buffer_ptr->GetDataSize(), sizeof(Uniforms));
     buffer_bindings.uniforms_buffer_ptr->SetData(m_mesh_buffers.GetFinalPassUniformsSubresources());
 
-    cmd_list.ResetWithState(m_render_state_ptr, s_debug_group.get());
+    cmd_list.ResetWithState(*m_render_state_ptr, s_debug_group.get());
     cmd_list.SetViewState(view_state);
     
     META_CHECK_ARG_NOT_EMPTY(buffer_bindings.program_bindings_per_instance);

--- a/Apps/Tutorials/01-HelloTriangle/HelloTriangleApp.cpp
+++ b/Apps/Tutorials/01-HelloTriangle/HelloTriangleApp.cpp
@@ -113,7 +113,7 @@ bool HelloTriangleApp::Render()
     // Issue commands for triangle rendering
     META_DEBUG_GROUP_CREATE_VAR(s_debug_group, "Triangle Rendering");
     const HelloTriangleFrame& frame = GetCurrentFrame();
-    frame.render_cmd_list_ptr->ResetWithState(m_render_state_ptr, s_debug_group.get());
+    frame.render_cmd_list_ptr->ResetWithState(*m_render_state_ptr, s_debug_group.get());
     frame.render_cmd_list_ptr->SetViewState(GetViewState());
     frame.render_cmd_list_ptr->SetVertexBuffers(*m_vertex_buffer_set_ptr);
     frame.render_cmd_list_ptr->Draw(gfx::RenderCommandList::Primitive::Triangle, 3U);

--- a/Apps/Tutorials/01-HelloTriangle/HelloTriangleAppSimple.cpp
+++ b/Apps/Tutorials/01-HelloTriangle/HelloTriangleAppSimple.cpp
@@ -127,7 +127,7 @@ public:
             return false;
 
         const HelloTriangleFrame& frame = GetCurrentFrame();
-        frame.render_cmd_list_ptr->ResetWithState(m_render_state_ptr);
+        frame.render_cmd_list_ptr->ResetWithState(*m_render_state_ptr);
         frame.render_cmd_list_ptr->SetViewState(GetViewState());
         frame.render_cmd_list_ptr->SetVertexBuffers(*m_vertex_buffer_set_ptr);
         frame.render_cmd_list_ptr->Draw(RenderCommandList::Primitive::Triangle, 3);

--- a/Apps/Tutorials/02-TexturedCube/TexturedCubeApp.cpp
+++ b/Apps/Tutorials/02-TexturedCube/TexturedCubeApp.cpp
@@ -223,7 +223,7 @@ bool TexturedCubeApp::Render()
 
     // Issue commands for cube rendering
     META_DEBUG_GROUP_CREATE_VAR(s_debug_group, "Cube Rendering");
-    frame.render_cmd_list_ptr->ResetWithState(m_render_state_ptr, s_debug_group.get());
+    frame.render_cmd_list_ptr->ResetWithState(*m_render_state_ptr, s_debug_group.get());
     frame.render_cmd_list_ptr->SetViewState(GetViewState());
     frame.render_cmd_list_ptr->SetProgramBindings(*frame.program_bindings_ptr);
     frame.render_cmd_list_ptr->SetVertexBuffers(*m_vertex_buffer_set_ptr);

--- a/Apps/Tutorials/03-ShadowCube/ShadowCubeApp.cpp
+++ b/Apps/Tutorials/03-ShadowCube/ShadowCubeApp.cpp
@@ -424,7 +424,7 @@ void ShadowCubeApp::RenderScene(const RenderPass &render_pass, const ShadowCubeF
     gfx::RenderCommandList& cmd_list = *render_pass_resources.cmd_list_ptr;
 
     // Reset command list with initial rendering state
-    cmd_list.ResetWithState(render_pass.render_state_ptr, render_pass.debug_group_ptr.get());
+    cmd_list.ResetWithState(*render_pass.render_state_ptr, render_pass.debug_group_ptr.get());
     cmd_list.SetViewState(*render_pass.view_state_ptr);
 
     // Draw scene with cube and floor

--- a/Apps/Tutorials/03-ShadowCube/ShadowCubeApp.h
+++ b/Apps/Tutorials/03-ShadowCube/ShadowCubeApp.h
@@ -102,9 +102,10 @@ private:
     public:
         using TexturedMeshBuffersBase::TexturedMeshBuffersBase;
 
-        void                SetShadowPassUniforms(MeshUniforms&& uniforms) noexcept             { m_shadow_pass_uniforms = std::move(uniforms); }
-        const MeshUniforms& GetShadowPassUniforms() const noexcept                              { return m_shadow_pass_uniforms; }
-        const gfx::Resource::SubResources& GetShadowPassUniformsSubresources() const noexcept   { return m_shadow_pass_uniforms_subresources; }
+        void SetShadowPassUniforms(MeshUniforms&& uniforms) noexcept { m_shadow_pass_uniforms = std::move(uniforms); }
+
+        [[nodiscard]] const MeshUniforms&                GetShadowPassUniforms() const noexcept               { return m_shadow_pass_uniforms; }
+        [[nodiscard]] const gfx::Resource::SubResources& GetShadowPassUniformsSubresources() const noexcept   { return m_shadow_pass_uniforms_subresources; }
 
     private:
         MeshUniforms                m_shadow_pass_uniforms{};

--- a/Apps/Tutorials/04-Typography/TypographyApp.cpp
+++ b/Apps/Tutorials/04-Typography/TypographyApp.cpp
@@ -251,20 +251,17 @@ void TypographyApp::UpdateFontAtlasBadges()
     // Remove obsolete font atlas badges
     for(auto badge_it = m_font_atlas_badges.begin(); badge_it != m_font_atlas_badges.end();)
     {
-        const Ptr<gui::Badge>& font_atlas_badge_ptr = *badge_it;
-        if (std::any_of(font_refs.begin(), font_refs.end(),
-                [&font_atlas_badge_ptr, &context](const Ref<gui::Font>& font_ref)
-                {
-                    return std::addressof(font_atlas_badge_ptr->GetTexture()) == font_ref.get().GetAtlasTexturePtr(context).get();
-                })
-            )
+        META_CHECK_ARG_NOT_NULL(*badge_it);
+        if (gui::Badge& badge = **badge_it;
+            std::any_of(font_refs.begin(), font_refs.end(),
+                [&badge, &context](const Ref<gui::Font>& font_ref)
+                { return std::addressof(badge.GetTexture()) == font_ref.get().GetAtlasTexturePtr(context).get(); }))
         {
             ++badge_it;
+            continue;
         }
-        else
-        {
-            badge_it = m_font_atlas_badges.erase(badge_it);
-        }
+
+        badge_it = m_font_atlas_badges.erase(badge_it);
     }
 
     // Add new font atlas badges

--- a/Apps/Tutorials/04-Typography/TypographyApp.cpp
+++ b/Apps/Tutorials/04-Typography/TypographyApp.cpp
@@ -252,19 +252,18 @@ void TypographyApp::UpdateFontAtlasBadges()
     for(auto badge_it = m_font_atlas_badges.begin(); badge_it != m_font_atlas_badges.end();)
     {
         const Ptr<gui::Badge>& font_atlas_badge_ptr = *badge_it;
-        const auto font_ref_it = std::find_if(font_refs.begin(), font_refs.end(),
-            [&font_atlas_badge_ptr, &context](const Ref<gui::Font>& font_ref)
-            {
-                return std::addressof(font_atlas_badge_ptr->GetTexture()) == font_ref.get().GetAtlasTexturePtr(context).get();
-            }
-        );
-        if (font_ref_it == font_refs.end())
+        if (std::any_of(font_refs.begin(), font_refs.end(),
+                [&font_atlas_badge_ptr, &context](const Ref<gui::Font>& font_ref)
+                {
+                    return std::addressof(font_atlas_badge_ptr->GetTexture()) == font_ref.get().GetAtlasTexturePtr(context).get();
+                })
+            )
         {
-            badge_it = m_font_atlas_badges.erase(badge_it);
+            ++badge_it;
         }
         else
         {
-            ++badge_it;
+            badge_it = m_font_atlas_badges.erase(badge_it);
         }
     }
 
@@ -272,17 +271,12 @@ void TypographyApp::UpdateFontAtlasBadges()
     for(const Ref<gui::Font>& font_ref : font_refs)
     {
         const Ptr<gfx::Texture>& font_atlas_texture_ptr = font_ref.get().GetAtlasTexturePtr(context);
-        if (!font_atlas_texture_ptr)
-            continue;
-
-        const auto font_atlas_ptr_it = std::find_if(m_font_atlas_badges.begin(), m_font_atlas_badges.end(),
-                                                   [&font_atlas_texture_ptr](const Ptr<gui::Badge>& font_atlas_badge_ptr)
-            {
-                return std::addressof(font_atlas_badge_ptr->GetTexture()) == font_atlas_texture_ptr.get();
-            }
-        );
-
-        if (font_atlas_ptr_it != m_font_atlas_badges.end())
+        if (!font_atlas_texture_ptr ||
+            std::any_of(m_font_atlas_badges.begin(), m_font_atlas_badges.end(),
+                        [&font_atlas_texture_ptr](const Ptr<gui::Badge>& font_atlas_badge_ptr)
+                        {
+                            return std::addressof(font_atlas_badge_ptr->GetTexture()) == font_atlas_texture_ptr.get();
+                        }))
             continue;
 
         m_font_atlas_badges.emplace_back(CreateFontAtlasBadge(font_ref.get(), font_atlas_texture_ptr));

--- a/Apps/Tutorials/04-Typography/TypographyApp.cpp
+++ b/Apps/Tutorials/04-Typography/TypographyApp.cpp
@@ -252,7 +252,7 @@ void TypographyApp::UpdateFontAtlasBadges()
     for(auto badge_it = m_font_atlas_badges.begin(); badge_it != m_font_atlas_badges.end();)
     {
         META_CHECK_ARG_NOT_NULL(*badge_it);
-        if (gui::Badge& badge = **badge_it;
+        if (const gui::Badge& badge = **badge_it;
             std::any_of(font_refs.begin(), font_refs.end(),
                 [&badge, &context](const Ref<gui::Font>& font_ref)
                 { return std::addressof(badge.GetTexture()) == font_ref.get().GetAtlasTexturePtr(context).get(); }))

--- a/Apps/Tutorials/04-Typography/TypographyApp.cpp
+++ b/Apps/Tutorials/04-Typography/TypographyApp.cpp
@@ -50,7 +50,7 @@ static const std::array<FontSettings, g_text_blocks_count> g_font_settings { {
 } };
 
 static const gfx::Color3f g_misc_font_color { 1.F, 1.F, 1.F };
-static const std::map<std::string, gfx::Color3f> g_font_color_by_name   {
+static const std::map<std::string, gfx::Color3f, std::less<>> g_font_color_by_name   {
     { g_font_settings[0].desc.name, g_font_settings[0].color },
     { g_font_settings[1].desc.name, g_font_settings[1].color },
     { g_font_settings[2].desc.name, g_font_settings[2].color },

--- a/Apps/Tutorials/04-Typography/TypographyApp.cpp
+++ b/Apps/Tutorials/04-Typography/TypographyApp.cpp
@@ -93,6 +93,7 @@ static const std::map<pal::Keyboard::State, TypographyAppAction> g_typography_ac
     { { pal::Keyboard::Key::Minus   }, TypographyAppAction::SlowdownTyping                },
 };
 
+[[nodiscard]]
 static gui::UnitRect GetTextBlockRectInDots(size_t block_index, int32_t vertical_pos_in_dots, const gfx::FrameSize& frame_size_in_dots)
 {
     return gui::UnitRect(

--- a/Apps/Tutorials/04-Typography/TypographyApp.h
+++ b/Apps/Tutorials/04-Typography/TypographyApp.h
@@ -45,8 +45,8 @@ using UserInterfaceApp = UserInterface::App<TypographyFrame>;
 
 class TypographyApp final
     : public UserInterfaceApp
-    , private Data::Receiver<gui::IFontLibraryCallback>
-    , private Data::Receiver<gui::IFontCallback>
+    , private Data::Receiver<gui::IFontLibraryCallback> // NOSONAR
+    , private Data::Receiver<gui::IFontCallback>        // NOSONAR
 {
 public:
     struct Settings

--- a/Modules/Common/Instrumentation/CMakeLists.txt
+++ b/Modules/Common/Instrumentation/CMakeLists.txt
@@ -12,8 +12,12 @@ set(HEADERS
     ${INCLUDE_DIR}/TracyGpu.hpp
 )
 
-set(SOURCES
+set(PLATFORM_SOURCES
     ${SOURCES_PLATFORM_DIR}/Instrumentation.${CPP_EXT}
+)
+
+set(SOURCES
+    ${PLATFORM_SOURCES}
     ${SOURCES_DIR}/Instrumentation.cpp
     ${SOURCES_DIR}/ScopeTimer.cpp
     $<$<BOOL:${METHANE_TRACY_PROFILING_ENABLED}>:${SOURCES_DIR}/InstrumentMemoryAllocations.cpp>
@@ -80,6 +84,15 @@ target_compile_definitions(TracyClient
 )
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${HEADERS} ${SOURCES})
+
+if (APPLE)
+    # Disable precompiled headers on MacOS for Objective-C files:
+    set_source_files_properties(
+        ${PLATFORM_SOURCES}
+        PROPERTIES
+            SKIP_PRECOMPILE_HEADERS ON
+    )
+endif()
 
 set_target_properties(${TARGET}
     PROPERTIES

--- a/Modules/Common/Instrumentation/Include/Methane/ILogger.h
+++ b/Modules/Common/Instrumentation/Include/Methane/ILogger.h
@@ -23,14 +23,14 @@ Abstract logger interface.
 
 #pragma once
 
-#include <string>
+#include <string_view>
 
 namespace Methane
 {
 
 struct ILogger
 {
-    virtual void Log(const std::string& message) = 0;
+    virtual void Log(std::string_view message) = 0;
 
     virtual ~ILogger() = default;
 };

--- a/Modules/Common/Instrumentation/Include/Methane/Instrumentation.h
+++ b/Modules/Common/Instrumentation/Include/Methane/Instrumentation.h
@@ -140,7 +140,7 @@ ITT_DOMAIN_EXTERN();
 
 #include <Methane/Platform/Utils.h>
 
-#define META_LOG(/*const std::string& */message, ...) \
+#define META_LOG(/*std::string_view*/message, ...) \
     Methane::Platform::PrintToDebugOutput(fmt::format(message, ## __VA_ARGS__))
 
 #else // ifdef METHANE_LOGGING_ENABLED

--- a/Modules/Common/Instrumentation/Include/Methane/Instrumentation.h
+++ b/Modules/Common/Instrumentation/Include/Methane/Instrumentation.h
@@ -29,11 +29,13 @@ NOTE:
 
 #pragma once
 
+#include "IttApiHelper.h"
+#include "ScopeTimer.h"
+
 #include <Tracy.hpp>
 #include <TracyC.h>
 
-#include "IttApiHelper.h"
-#include "ScopeTimer.h"
+#include <string_view>
 
 #if defined(ITT_INSTRUMENTATION_ENABLED) || defined(TRACY_ENABLE)
 #define META_INSTRUMENTATION_ENABLED
@@ -41,7 +43,7 @@ NOTE:
 
 namespace Methane
 {
-void SetThreadName(const char* name);
+void SetThreadName(std::string_view name);
 }
 
 constexpr const char* g_methane_itt_domain_name = "Methane Kit";

--- a/Modules/Common/Instrumentation/Include/Methane/ScopeTimer.h
+++ b/Modules/Common/Instrumentation/Include/Methane/ScopeTimer.h
@@ -57,7 +57,7 @@ public:
             uint32_t     count    = 0U;
         };
 
-        static Aggregator& Get();
+        [[nodiscard]] static Aggregator& Get();
 
         Aggregator(const Aggregator&) = delete;
         Aggregator(Aggregator&&) = delete;

--- a/Modules/Common/Instrumentation/Include/Methane/ScopeTimer.h
+++ b/Modules/Common/Instrumentation/Include/Methane/ScopeTimer.h
@@ -66,8 +66,8 @@ public:
         Aggregator& operator=(const Aggregator&) = delete;
         Aggregator& operator=(Aggregator&&) = delete;
 
-        void SetLogger(Ptr<ILogger> logger_ptr)   { m_logger_ptr = std::move(logger_ptr); }
-        const Ptr<ILogger>& GetLogger() const    { return m_logger_ptr; }
+        void SetLogger(Ptr<ILogger> logger_ptr)             { m_logger_ptr = std::move(logger_ptr); }
+        [[nodiscard]] const Ptr<ILogger>& GetLogger() const { return m_logger_ptr; }
 
         void LogTimings(ILogger& logger);
         void Flush();
@@ -104,9 +104,9 @@ public:
     ScopeTimer& operator=(const ScopeTimer&) = delete;
     ScopeTimer& operator=(ScopeTimer&&) = delete;
 
-    const Registration& GetRegistration() const { return m_registration; }
-    const char*         GetScopeName() const    { return m_registration.name; }
-    ScopeId             GetScopeId() const      { return m_registration.id; }
+    [[nodiscard]] const Registration& GetRegistration() const { return m_registration; }
+    [[nodiscard]] const char*         GetScopeName() const    { return m_registration.name; }
+    [[nodiscard]] ScopeId             GetScopeId() const      { return m_registration.id; }
 
 private:
     using Timer::Reset;

--- a/Modules/Common/Instrumentation/Include/Methane/TracyGpu.hpp
+++ b/Modules/Common/Instrumentation/Include/Methane/TracyGpu.hpp
@@ -149,7 +149,7 @@ public:
 private:
     tracy_force_inline QueryId NextQueryId()
     {
-        std::lock_guard<LockableBase(std::mutex)> lock_guard(m_query_mutex);
+        std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_query_mutex);
         m_query_id = (m_query_id + 1) % m_query_count;
         return m_query_id;
     }

--- a/Modules/Common/Instrumentation/Sources/Methane/Linux/Instrumentation.cpp
+++ b/Modules/Common/Instrumentation/Sources/Methane/Linux/Instrumentation.cpp
@@ -24,23 +24,24 @@ Linux implementation of the platform specific instrumentation functions.
 #include <pthread.h>
 
 #include <cstring>
+#include <string_view>
 #include <array>
 
 namespace Methane
 {
 
-void SetThreadName(const char* name)
+void SetThreadName(std::string_view name)
 {
-    if(strlen(name) < 16)
+    if(name.length() < 16)
     {
-        pthread_setname_np(pthread_self(), name);
+        pthread_setname_np(pthread_self(), name.data());
         return;
     }
 
     std::array<char, 16> buf;
-    memcpy(buf, name, 15);
+    memcpy(buf.data(), name.data(), 15);
     buf[15] = '\0';
-    pthread_setname_np(pthread_self(), buf);
+    pthread_setname_np(pthread_self(), buf.data());
 }
 
 } // namespace Methane

--- a/Modules/Common/Instrumentation/Sources/Methane/Linux/Instrumentation.cpp
+++ b/Modules/Common/Instrumentation/Sources/Methane/Linux/Instrumentation.cpp
@@ -30,14 +30,13 @@ namespace Methane
 
 void SetThreadName(const char* name)
 {
-    const std::size_t name_length = strlen(name);
-    if(name_length < 16)
+    if(strlen(name) < 16)
     {
-        pthread_setname_np(pthread_self(), name );
+        pthread_setname_np(pthread_self(), name);
         return;
     }
 
-    char buf[16];
+    std::array<char, 16> buf;
     memcpy(buf, name, 15);
     buf[15] = '\0';
     pthread_setname_np(pthread_self(), buf);

--- a/Modules/Common/Instrumentation/Sources/Methane/Linux/Instrumentation.cpp
+++ b/Modules/Common/Instrumentation/Sources/Methane/Linux/Instrumentation.cpp
@@ -24,6 +24,7 @@ Linux implementation of the platform specific instrumentation functions.
 #include <pthread.h>
 
 #include <cstring>
+#include <array>
 
 namespace Methane
 {

--- a/Modules/Common/Instrumentation/Sources/Methane/MacOS/Instrumentation.mm
+++ b/Modules/Common/Instrumentation/Sources/Methane/MacOS/Instrumentation.mm
@@ -22,17 +22,20 @@ MacOS implementation of the platform specific instrumentation functions.
 ******************************************************************************/
 
 #include <pthread.h>
+#include <string_view>
 
 #import <Foundation/Foundation.h>
 
 namespace Methane
 {
 
-void SetThreadName(const char* name)
+void SetThreadName(std::string_view name)
 {
-    NSString* ns_name = [[NSString alloc] initWithUTF8String:name];
+    NSString* ns_name = [[NSString alloc] initWithBytes:name.data()
+                                                 length:name.length()
+                                               encoding:NSUTF8StringEncoding];
     [[NSThread currentThread] setName:ns_name];
-    pthread_setname_np(name);
+    pthread_setname_np(name.data());
 }
 
 } // namespace Methane

--- a/Modules/Common/Instrumentation/Sources/Methane/ScopeTimer.cpp
+++ b/Modules/Common/Instrumentation/Sources/Methane/ScopeTimer.cpp
@@ -66,10 +66,8 @@ void ScopeTimer::Aggregator::LogTimings(ILogger& logger)
     std::stringstream ss;
     ss << std::endl << "Aggregated performance timings:" << std::endl;
 
-    for (const auto& scope_name_and_id : m_scope_id_by_name)
+    for (const auto& [scope_name, scope_id] : m_scope_id_by_name)
     {
-        const std::string& scope_name = scope_name_and_id.first;
-        const ScopeId      scope_id   = scope_name_and_id.second;
         META_CHECK_ARG_LESS(scope_id, m_timing_by_scope_id.size());
 
         const Timing& scope_timing = m_timing_by_scope_id[scope_id];

--- a/Modules/Common/Instrumentation/Sources/Methane/ScopeTimer.cpp
+++ b/Modules/Common/Instrumentation/Sources/Methane/ScopeTimer.cpp
@@ -94,7 +94,7 @@ ScopeTimer::Registration ScopeTimer::Aggregator::RegisterScope(const char* scope
         m_new_scope_id++;
         m_timing_by_scope_id.resize(m_new_scope_id);
         m_counters_by_scope_id.emplace_back(ITT_COUNTER_INIT(scope_name_and_id_it->first, g_methane_itt_domain_name));
-        TracyPlotConfig(result.first->first, tracy::PlotFormatType::Number);
+        TracyPlotConfig(scope_name_and_id_it->first, tracy::PlotFormatType::Number);
     }
     return Registration{ scope_name_and_id_it->first, scope_name_and_id_it->second };
 }

--- a/Modules/Common/Instrumentation/Sources/Methane/ScopeTimer.cpp
+++ b/Modules/Common/Instrumentation/Sources/Methane/ScopeTimer.cpp
@@ -88,15 +88,15 @@ void ScopeTimer::Aggregator::LogTimings(ILogger& logger)
 ScopeTimer::Registration ScopeTimer::Aggregator::RegisterScope(const char* scope_name)
 {
     META_FUNCTION_TASK();
-    const auto result = m_scope_id_by_name.emplace(scope_name, m_new_scope_id);
-    if (result.second)
+    const auto [ scope_name_and_id_it, scope_added ] = m_scope_id_by_name.try_emplace(scope_name, m_new_scope_id);
+    if (scope_added)
     {
         m_new_scope_id++;
         m_timing_by_scope_id.resize(m_new_scope_id);
-        m_counters_by_scope_id.emplace_back(ITT_COUNTER_INIT(result.first->first, g_methane_itt_domain_name));
+        m_counters_by_scope_id.emplace_back(ITT_COUNTER_INIT(scope_name_and_id_it->first, g_methane_itt_domain_name));
         TracyPlotConfig(result.first->first, tracy::PlotFormatType::Number);
     }
-    return Registration{ result.first->first, result.first->second };
+    return Registration{ scope_name_and_id_it->first, scope_name_and_id_it->second };
 }
 
 void ScopeTimer::Aggregator::AddScopeTiming(const Registration& scope_registration, TimeDuration duration)

--- a/Modules/Common/Instrumentation/Sources/Methane/Windows/Instrumentation.cpp
+++ b/Modules/Common/Instrumentation/Sources/Methane/Windows/Instrumentation.cpp
@@ -71,8 +71,8 @@ extern "C" typedef HRESULT (WINAPI* SetThreadDescriptionFn)(HANDLE, PCWSTR);
 
 void SetThreadName(const char* name)
 {
-    static auto s_set_thread_description_fn = reinterpret_cast<SetThreadDescriptionFn>(GetProcAddress(GetModuleHandleA("kernel32.dll"), "SetThreadDescription"));
-    if (s_set_thread_description_fn)
+    if (static auto s_set_thread_description_fn = reinterpret_cast<SetThreadDescriptionFn>(GetProcAddress(GetModuleHandleA("kernel32.dll"), "SetThreadDescription"));
+        s_set_thread_description_fn)
     {
         const std::wstring w_name = nowide::widen(name);
         s_set_thread_description_fn(GetCurrentThread(), w_name.c_str());

--- a/Modules/Common/Instrumentation/Sources/Methane/Windows/Instrumentation.cpp
+++ b/Modules/Common/Instrumentation/Sources/Methane/Windows/Instrumentation.cpp
@@ -23,6 +23,7 @@ Windows implementation of the platform specific instrumentation functions.
 
 #include <Windows.h>
 
+#include <string_view>
 #include <nowide/convert.hpp>
 
 namespace Methane
@@ -40,13 +41,13 @@ struct ThreadNameInfo
 };
 #pragma pack(pop)
 
-static void SetLegacyThreadName(const char* name)
+static void SetLegacyThreadName(std::string_view name)
 {
     // Set thread name with legacy exception way
     constexpr DWORD msvc_exception = 0x406D1388;
     ThreadNameInfo info {
         0x1000,
-        name,
+        name.data(),
         GetCurrentThreadId(),
         0
     };
@@ -63,18 +64,18 @@ static void SetLegacyThreadName(const char* name)
 
 #else
 
-static void SetLegacyThreadName(const char*) { }
+static void SetLegacyThreadName(std::string_view) { }
 
 #endif
 
 extern "C" typedef HRESULT (WINAPI* SetThreadDescriptionFn)(HANDLE, PCWSTR);
 
-void SetThreadName(const char* name)
+void SetThreadName(std::string_view name)
 {
     if (static auto s_set_thread_description_fn = reinterpret_cast<SetThreadDescriptionFn>(GetProcAddress(GetModuleHandleA("kernel32.dll"), "SetThreadDescription"));
         s_set_thread_description_fn)
     {
-        const std::wstring w_name = nowide::widen(name);
+        const std::wstring w_name = nowide::widen(name.data(), name.length());
         s_set_thread_description_fn(GetCurrentThread(), w_name.c_str());
     }
     else

--- a/Modules/Common/PrecompiledHeaders/CMakeLists.txt
+++ b/Modules/Common/PrecompiledHeaders/CMakeLists.txt
@@ -29,6 +29,7 @@ set(PRECOMPILED_HEADERS ${PRECOMPILED_HEADERS}
     # types
     <limits>
     <string>
+    <string_view>
     <sstream>
     <tuple>
     <optional>

--- a/Modules/Common/Primitives/Include/Methane/Exceptions.hpp
+++ b/Modules/Common/Primitives/Include/Methane/Exceptions.hpp
@@ -54,8 +54,8 @@ public:
         , m_argument_name(argument_name)
     { }
 
-    const std::string& GetFunctionName() const noexcept { return m_function_name; }
-    const std::string& GetArgumentName() const noexcept { return m_argument_name; }
+    [[nodiscard]] const std::string& GetFunctionName() const noexcept { return m_function_name; }
+    [[nodiscard]] const std::string& GetArgumentName() const noexcept { return m_argument_name; }
 
 private:
     const std::string m_function_name;
@@ -91,14 +91,14 @@ public:
         , m_value(std::move(value))
     { }
 
-    const DecayType& GetValue() const noexcept { return m_value; }
+    [[nodiscard]] const DecayType& GetValue() const noexcept { return m_value; }
 
 private:
     template<typename V = DecayType, typename = V>
-    static std::string GetMessage(V value) noexcept { return fmt::format("{}({}) is not valid", typeid(T).name(), value); }
+    [[nodiscard]] static std::string GetMessage(V value) noexcept { return fmt::format("{}({}) is not valid", typeid(T).name(), value); }
 
     template<typename V = DecayType, std::enable_if_t<IsStaticCastable<V, std::string>::value, void>>
-    static std::string GetMessage(V value) noexcept { return fmt::format("{}({}) is not valid", typeid(T).name(), static_cast<std::string>(value)); }
+    [[nodiscard]] static std::string GetMessage(V value) noexcept { return fmt::format("{}({}) is not valid", typeid(T).name(), static_cast<std::string>(value)); }
 
     const DecayType m_value{ };
 };
@@ -115,8 +115,8 @@ public:
         , m_range(std::move(range))
     { }
 
-    const T& GetValue() const noexcept               { return m_value; }
-    const std::pair<T, T>& GetRange() const noexcept { return m_range; }
+    [[nodiscard]] const T& GetValue() const noexcept               { return m_value; }
+    [[nodiscard]] const std::pair<T, T>& GetRange() const noexcept { return m_range; }
 
 private:
     const DecayType m_value;
@@ -159,7 +159,7 @@ public:
         , m_value(value)
     { }
 
-    T GetValue() const noexcept { m_value; }
+    [[nodiscard]] T GetValue() const noexcept { m_value; }
 
 private:
     const T m_value;
@@ -173,7 +173,7 @@ public:
         , m_function_name(function_name)
     { }
 
-    const std::string& GetFunctionName() const noexcept { return m_function_name; }
+    [[nodiscard]] const std::string& GetFunctionName() const noexcept { return m_function_name; }
 
 private:
     const std::string m_function_name;

--- a/Modules/Common/Primitives/Include/Methane/Timer.hpp
+++ b/Modules/Common/Primitives/Include/Methane/Timer.hpp
@@ -37,14 +37,14 @@ public:
 
     Timer() = default;
 
-    TimePoint    GetStartTime() const noexcept       { return m_start_time; }
-    TimeDuration GetElapsedDuration() const noexcept { return Clock::now() - m_start_time; }
-    uint32_t     GetElapsedSecondsU() const noexcept { return GetElapsedSeconds<uint32_t>(); }
-    double       GetElapsedSecondsD() const noexcept { return GetElapsedSeconds<double>(); }
-    float        GetElapsedSecondsF() const noexcept { return GetElapsedSeconds<float>(); }
+    [[nodiscard]] TimePoint    GetStartTime() const noexcept       { return m_start_time; }
+    [[nodiscard]] TimeDuration GetElapsedDuration() const noexcept { return Clock::now() - m_start_time; }
+    [[nodiscard]] uint32_t     GetElapsedSecondsU() const noexcept { return GetElapsedSeconds<uint32_t>(); }
+    [[nodiscard]] double       GetElapsedSecondsD() const noexcept { return GetElapsedSeconds<double>(); }
+    [[nodiscard]] float        GetElapsedSecondsF() const noexcept { return GetElapsedSeconds<float>(); }
 
     template<typename T>
-    T GetElapsedSeconds() const noexcept
+    [[nodiscard]] T GetElapsedSeconds() const noexcept
     {
         return std::chrono::duration_cast<std::chrono::duration<T>>(GetElapsedDuration()).count();
     }

--- a/Modules/Data/Animation/Include/Methane/Data/Animation.h
+++ b/Modules/Data/Animation/Include/Methane/Data/Animation.h
@@ -46,9 +46,10 @@ public:
     Animation& operator=(const Animation&) = delete;
     Animation& operator=(Animation&&) = default;
 
-    State  GetState() const noexcept             { return m_state; }
-    double GetDuration() const noexcept          { return m_duration_sec; }
-    void   SetDuration(double duration_sec)      { m_duration_sec = duration_sec; }
+    [[nodiscard]] State  GetState() const noexcept    { return m_state; }
+    [[nodiscard]] double GetDuration() const noexcept { return m_duration_sec; }
+
+    void   SetDuration(double duration_sec)           { m_duration_sec = duration_sec; }
     void   IncreaseDuration(double duration_sec);
 
     virtual void Restart() noexcept;
@@ -60,7 +61,7 @@ public:
     void Resume();
 
 protected:
-    bool IsTimeOver() const noexcept { return GetElapsedSecondsD() >= m_duration_sec; }
+    [[nodiscard]] bool IsTimeOver() const noexcept { return GetElapsedSecondsD() >= m_duration_sec; }
 
     using Timer::Reset;
 

--- a/Modules/Data/Animation/Include/Methane/Data/AnimationsPool.h
+++ b/Modules/Data/Animation/Include/Methane/Data/AnimationsPool.h
@@ -44,8 +44,9 @@ public:
 
     // When animations are paused dry updates are called on every app update at the same point in time,
     // such behavior consumes CPU cycles on pause but could be useful to keep GPU state in sync with CPU when it does not depend just on animation time
-    bool IsPaused() const noexcept                          { return m_is_paused; }
-    bool IsDryUpdateOnPauseEnabled() const noexcept         { return m_is_dry_update_on_pause_enabled; }
+    [[nodiscard]] bool IsPaused() const noexcept                  { return m_is_paused; }
+    [[nodiscard]] bool IsDryUpdateOnPauseEnabled() const noexcept { return m_is_dry_update_on_pause_enabled; }
+
     void SetDryUpdateOnPauseEnabled(bool enabled) noexcept  { m_is_dry_update_on_pause_enabled = enabled; }
 
 private:

--- a/Modules/Data/Animation/Sources/Methane/Data/AnimationsPool.cpp
+++ b/Modules/Data/Animation/Sources/Methane/Data/AnimationsPool.cpp
@@ -45,8 +45,8 @@ void AnimationsPool::Update()
     std::vector<size_t> completed_animation_indices;
     for (size_t animation_index = 0; animation_index < size(); ++animation_index)
     {
-        const Ptr<Animation>& animation_ptr = (*this)[animation_index];
-        if (!animation_ptr || !animation_ptr->Update())
+        if (const Ptr<Animation>& animation_ptr = (*this)[animation_index];
+            !animation_ptr || !animation_ptr->Update())
         {
             completed_animation_indices.push_back(animation_index);
         }

--- a/Modules/Data/Animation/Sources/Methane/Data/TimeAnimation.cpp
+++ b/Modules/Data/Animation/Sources/Methane/Data/TimeAnimation.cpp
@@ -48,8 +48,7 @@ bool TimeAnimation::Update()
         return false;
 
     const double elapsed_seconds = GetElapsedSecondsD();
-    const double delta_seconds = elapsed_seconds - m_prev_elapsed_seconds;
-    if (IsTimeOver() || !m_update_function(elapsed_seconds, delta_seconds))
+    if (IsTimeOver() || !m_update_function(elapsed_seconds, elapsed_seconds - m_prev_elapsed_seconds))
     {
         Stop();
     }

--- a/Modules/Data/Events/Include/Methane/Data/Emitter.hpp
+++ b/Modules/Data/Events/Include/Methane/Data/Emitter.hpp
@@ -84,8 +84,7 @@ public:
     void Connect(Receiver<EventType>& receiver) noexcept override
     {
         META_FUNCTION_TASK();
-        const auto connected_receiver_it = FindConnectedReceiver(receiver);
-        if (connected_receiver_it != m_connected_receivers.end())
+        if (FindConnectedReceiver(receiver) != m_connected_receivers.end())
             return;
 
         if (m_is_emitting)

--- a/Modules/Data/Events/Include/Methane/Data/Emitter.hpp
+++ b/Modules/Data/Events/Include/Methane/Data/Emitter.hpp
@@ -51,7 +51,7 @@ public:
         ConnectReceivers();
     }
 
-    ~Emitter() override
+    ~Emitter() override // NOSONAR
     {
         META_FUNCTION_TASK();
         DisconnectReceivers();
@@ -161,6 +161,7 @@ protected:
     size_t GetConnectedReceiversCount() const noexcept { return m_connected_receivers.size() + m_additional_connected_receivers.size(); }
 
 private:
+    [[nodiscard]]
     inline decltype(auto) FindConnectedReceiver(Receiver<EventType>& receiver) noexcept
     {
         return std::find_if(m_connected_receivers.begin(), m_connected_receivers.end(),

--- a/Modules/Data/Events/Include/Methane/Data/Receiver.hpp
+++ b/Modules/Data/Events/Include/Methane/Data/Receiver.hpp
@@ -90,8 +90,7 @@ protected:
     void OnConnected(IEmitter<EventType>& emitter) noexcept
     {
         META_FUNCTION_TASK();
-        const auto connected_emitter_ref_it = FindConnectedEmitter(emitter);
-        if (connected_emitter_ref_it != m_connected_emitter_refs.end())
+        if (FindConnectedEmitter(emitter) != m_connected_emitter_refs.end())
             return;
 
         m_connected_emitter_refs.emplace_back(emitter);

--- a/Modules/Data/Events/Include/Methane/Data/Receiver.hpp
+++ b/Modules/Data/Events/Include/Methane/Data/Receiver.hpp
@@ -53,7 +53,7 @@ public:
         ConnectEmitters();
     }
 
-    ~Receiver() override
+    ~Receiver() override // NOSONAR
     {
         META_FUNCTION_TASK();
         DisconnectEmitters();
@@ -107,9 +107,10 @@ protected:
         m_connected_emitter_refs.erase(connected_emitter_ref_it);
     }
 
-    size_t GetConnectedEmittersCount() const noexcept { return m_connected_emitter_refs.size(); }
+    [[nodiscard]] size_t GetConnectedEmittersCount() const noexcept { return m_connected_emitter_refs.size(); }
 
 private:
+    [[nodiscard]]
     inline decltype(auto) FindConnectedEmitter(IEmitter<EventType>& emitter) noexcept
     {
         return std::find_if(m_connected_emitter_refs.begin(), m_connected_emitter_refs.end(),

--- a/Modules/Data/Primitives/Include/Methane/Data/AlignedAllocator.hpp
+++ b/Modules/Data/Primitives/Include/Methane/Data/AlignedAllocator.hpp
@@ -95,7 +95,7 @@ public:
         p->~value_type(); // NOSONAR
     }
 
-    size_type max_size() const noexcept
+    [[nodiscard]] size_type max_size() const noexcept
     {
         return size_type(-1) / sizeof(value_type);
     }

--- a/Modules/Data/Primitives/Include/Methane/Data/AlignedAllocator.hpp
+++ b/Modules/Data/Primitives/Include/Methane/Data/AlignedAllocator.hpp
@@ -69,8 +69,7 @@ public:
         return static_cast<pointer>(_aligned_malloc(allocate_size, N));
 #else
         void* p_memory = nullptr;
-        const int error = posix_memalign(&p_memory, N, allocate_size);
-        if (error)
+        if (posix_memalign(&p_memory, N, allocate_size))
             throw std::bad_alloc();
         return static_cast<pointer>(p_memory);
 #endif

--- a/Modules/Data/Primitives/Include/Methane/Data/RectBinPack.hpp
+++ b/Modules/Data/Primitives/Include/Methane/Data/RectBinPack.hpp
@@ -84,8 +84,8 @@ private:
 
                 // Split node rectangle either vertically or horizontally,
                 // by creating small rectangle and one big rectangle representing free area not taken by glyph
-                const TSize delta = m_rect.size - rect.size;
-                if (delta.width < delta.height)
+                if (const TSize delta = m_rect.size - rect.size;
+                    delta.width < delta.height)
                 {
                     // Small top rectangle, to the right of character glyph
                     m_small_bin_ptr = std::make_unique<Bin>(TRect{

--- a/Modules/Data/Primitives/Include/Methane/Data/RectBinPack.hpp
+++ b/Modules/Data/Primitives/Include/Methane/Data/RectBinPack.hpp
@@ -67,8 +67,8 @@ private:
     public:
         explicit Bin(TRect rect) : m_rect(std::move(rect)) { META_FUNCTION_TASK(); }
 
-        bool         IsEmpty() const noexcept { return !m_small_bin_ptr && !m_large_bin_ptr; }
-        const TRect& GetRect() const noexcept { return m_rect; }
+        [[nodiscard]] bool         IsEmpty() const noexcept { return !m_small_bin_ptr && !m_large_bin_ptr; }
+        [[nodiscard]] const TRect& GetRect() const noexcept { return m_rect; }
 
         bool TryPack(TRect& rect, const TSize& char_margins)
         {

--- a/Modules/Data/Provider/Include/Methane/Data/FileProvider.hpp
+++ b/Modules/Data/Provider/Include/Methane/Data/FileProvider.hpp
@@ -40,20 +40,20 @@ namespace Methane::Data
 class FileProvider : public Provider
 {
 public:
-    static Provider& Get()
+    [[nodiscard]] static Provider& Get()
     {
         META_FUNCTION_TASK();
         static FileProvider s_instance;
         return s_instance;
     }
 
-    bool HasData(const std::string& path) const noexcept override
+    [[nodiscard]] bool HasData(const std::string& path) const noexcept override
     {
         META_FUNCTION_TASK();
         return std::ifstream(GetFullFilePath(path)).good();
     }
 
-    Data::Chunk GetData(const std::string& path) const override
+    [[nodiscard]] Data::Chunk GetData(const std::string& path) const override
     {
         META_FUNCTION_TASK();
 
@@ -73,7 +73,7 @@ public:
 protected:
     FileProvider() = default;
 
-    std::string GetFullFilePath(const std::string& path) const
+    [[nodiscard]] std::string GetFullFilePath(const std::string& path) const
     {
         META_FUNCTION_TASK();
 #ifdef _WIN32

--- a/Modules/Data/Provider/Include/Methane/Data/FileProvider.hpp
+++ b/Modules/Data/Provider/Include/Methane/Data/FileProvider.hpp
@@ -65,7 +65,7 @@ public:
         Data::Bytes buffer(static_cast<size_t>(fs.tellg()), {});
 
         fs.seekg(0,std::ios::beg);
-        fs.read(reinterpret_cast<char*>(buffer.data()), buffer.size());
+        fs.read(reinterpret_cast<char*>(buffer.data()), buffer.size()); // NOSONAR
 
         return Data::Chunk(std::move(buffer));
     }

--- a/Modules/Data/Provider/Include/Methane/Data/FileProvider.hpp
+++ b/Modules/Data/Provider/Include/Methane/Data/FileProvider.hpp
@@ -61,7 +61,13 @@ public:
         std::ifstream fs(file_path, std::ios::binary);
         META_CHECK_ARG_DESCR(path, fs.good(), "File path does not exist '{}'", file_path);
 
-        return Data::Chunk(Data::Bytes(std::istreambuf_iterator<char>(fs), {}));
+        fs.seekg(0,std::ios::end);
+        Data::Bytes buffer(static_cast<size_t>(fs.tellg()), {});
+
+        fs.seekg(0,std::ios::beg);
+        fs.read(reinterpret_cast<char*>(buffer.data()), buffer.size());
+
+        return Data::Chunk(std::move(buffer));
     }
 
 protected:

--- a/Modules/Data/Provider/Include/Methane/Data/ResourceProvider.hpp
+++ b/Modules/Data/Provider/Include/Methane/Data/ResourceProvider.hpp
@@ -42,14 +42,14 @@ namespace RESOURCE_NAMESPACE
 class ResourceProvider final : public Methane::Data::FileProvider
 {
 public:
-    static Provider& Get()
+    [[nodiscard]] static Provider& Get()
     {
         META_FUNCTION_TASK();
         static ResourceProvider s_instance;
         return s_instance;
     }
 
-    bool HasData(const std::string& path) const noexcept override
+    [[nodiscard]] bool HasData(const std::string& path) const noexcept override
     {
         META_FUNCTION_TASK();
 
@@ -59,7 +59,7 @@ public:
         return FileProvider::HasData(path);
     }
 
-    Methane::Data::Chunk GetData(const std::string& path) const override
+    [[nodiscard]] Methane::Data::Chunk GetData(const std::string& path) const override
     {
         META_FUNCTION_TASK();
 

--- a/Modules/Data/RangeSet/Include/Methane/Data/Range.hpp
+++ b/Modules/Data/RangeSet/Include/Methane/Data/Range.hpp
@@ -47,21 +47,22 @@ public:
     ~Range() = default;
 
     Range<ScalarT>& operator=(const Range<ScalarT>& other) noexcept        { m_start = other.m_start; m_end = other.m_end; return *this; }
-    bool            operator==(const Range<ScalarT>& other) const noexcept { return m_start == other.m_start && m_end == other.m_end; }
-    bool            operator!=(const Range<ScalarT>& other) const noexcept { return !operator==(other); }
-    bool            operator< (const Range<ScalarT>& other) const noexcept { return m_end  <= other.m_start; }
-    bool            operator> (const Range<ScalarT>& other) const noexcept { return m_start > other.end; }
+    [[nodiscard]] bool            operator==(const Range<ScalarT>& other) const noexcept { return m_start == other.m_start && m_end == other.m_end; }
+    [[nodiscard]] bool            operator!=(const Range<ScalarT>& other) const noexcept { return !operator==(other); }
+    [[nodiscard]] bool            operator< (const Range<ScalarT>& other) const noexcept { return m_end  <= other.m_start; }
+    [[nodiscard]] bool            operator> (const Range<ScalarT>& other) const noexcept { return m_start > other.end; }
 
-    ScalarT GetStart() const noexcept                           { return m_start; }
-    ScalarT GetEnd() const noexcept                             { return m_end; }
-    ScalarT GetLength() const noexcept                          { return m_end - m_start; }
-    bool    IsEmpty() const noexcept                            { return m_start == m_end; }
+    [[nodiscard]] ScalarT GetStart() const noexcept                           { return m_start; }
+    [[nodiscard]] ScalarT GetEnd() const noexcept                             { return m_end; }
+    [[nodiscard]] ScalarT GetLength() const noexcept                          { return m_end - m_start; }
+    [[nodiscard]] bool    IsEmpty() const noexcept                            { return m_start == m_end; }
 
-    bool    IsAdjacent(const Range& other) const noexcept       { return m_start == other.m_end   || other.m_start == m_end; }
-    bool    IsOverlapping(const Range& other) const noexcept    { return m_start <  other.m_end   && other.m_start <  m_end; }
-    bool    IsMergeable(const Range& other) const noexcept      { return m_start <= other.m_end   && other.m_start <= m_end; }
-    bool    Contains(const Range& other) const noexcept         { return m_start <= other.m_start && other.m_end   <= m_end; }
+    [[nodiscard]] bool    IsAdjacent(const Range& other) const noexcept       { return m_start == other.m_end   || other.m_start == m_end; }
+    [[nodiscard]] bool    IsOverlapping(const Range& other) const noexcept    { return m_start <  other.m_end   && other.m_start <  m_end; }
+    [[nodiscard]] bool    IsMergeable(const Range& other) const noexcept      { return m_start <= other.m_end   && other.m_start <= m_end; }
+    [[nodiscard]] bool    Contains(const Range& other) const noexcept         { return m_start <= other.m_start && other.m_end   <= m_end; }
 
+    [[nodiscard]]
     Range operator+(const Range& other) const // merge
     {
         META_FUNCTION_TASK();
@@ -69,6 +70,7 @@ public:
         return Range(std::min(m_start, other.m_start), std::max(m_end, other.m_end));
     }
 
+    [[nodiscard]]
     Range operator%(const Range& other) const // intersect
     {
         META_FUNCTION_TASK();
@@ -76,6 +78,7 @@ public:
         return Range(std::max(m_start, other.m_start), std::min(m_end, other.m_end));
     }
 
+    [[nodiscard]]
     Range operator-(const Range& other) const // subtract
     {
         META_FUNCTION_TASK();
@@ -84,8 +87,8 @@ public:
         return (m_start <= other.m_start) ? Range(m_start, other.m_start) : Range(other.m_end, m_end);
     }
 
-    explicit operator bool() const noexcept        { return !IsEmpty(); }
-    explicit operator std::string() const noexcept { META_FUNCTION_TASK(); return fmt::format("[{}, {})", m_start, m_end); }
+    [[nodiscard]] explicit operator bool() const noexcept        { return !IsEmpty(); }
+    [[nodiscard]] explicit operator std::string() const noexcept { META_FUNCTION_TASK(); return fmt::format("[{}, {})", m_start, m_end); }
 
 private:
     ScalarT m_start;
@@ -99,5 +102,5 @@ struct fmt::formatter<Methane::Data::Range<ScalarT>>
 {
     template<typename FormatContext>
     auto format(const Methane::Data::Range<ScalarT>& range, FormatContext& ctx) { return format_to(ctx.out(), "{}", static_cast<std::string>(range)); }
-    constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
+    [[nodiscard]] constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
 };

--- a/Modules/Data/RangeSet/Include/Methane/Data/RangeSet.hpp
+++ b/Modules/Data/RangeSet/Include/Methane/Data/RangeSet.hpp
@@ -46,8 +46,8 @@ public:
     RangeSet() = default;
     RangeSet(std::initializer_list<Range<ScalarT>> init) noexcept : m_container(init) { } //NOSONAR - initializer list constructor is not explicit intentionally
 
-    bool operator==(const RangeSet<ScalarT>& other) const noexcept { META_FUNCTION_TASK(); return m_container == other.m_container; }
-    bool operator==(const BaseSet& other) const noexcept           { META_FUNCTION_TASK(); return m_container == other; }
+    [[nodiscard]] bool operator==(const RangeSet<ScalarT>& other) const noexcept { META_FUNCTION_TASK(); return m_container == other.m_container; }
+    [[nodiscard]] bool operator==(const BaseSet& other) const noexcept           { META_FUNCTION_TASK(); return m_container == other; }
 
     RangeSet<ScalarT>& operator=(std::initializer_list<Range<ScalarT>> init) noexcept
     {
@@ -57,13 +57,19 @@ public:
         return *this;
     }
 
-    size_t Size() const noexcept              { return m_container.size();  }
-    bool   IsEmpty() const noexcept           { return m_container.empty(); }
-    void   Clear() noexcept                   { META_FUNCTION_TASK(); m_container.clear(); }
 
-    const BaseSet& GetRanges() const noexcept { return *this; }
-    ConstIterator begin() const noexcept      { return m_container.begin(); }
-    ConstIterator end() const noexcept        { return m_container.end(); }
+
+    [[nodiscard]] size_t Size() const noexcept              { return m_container.size();  }
+    [[nodiscard]] bool   IsEmpty() const noexcept           { return m_container.empty(); }
+    [[nodiscard]] const BaseSet& GetRanges() const noexcept { return *this; }
+    [[nodiscard]] ConstIterator begin() const noexcept      { return m_container.begin(); }
+    [[nodiscard]] ConstIterator end() const noexcept        { return m_container.end(); }
+
+    void Clear() noexcept
+    {
+        META_FUNCTION_TASK();
+        m_container.clear();
+    }
 
     void Add(const Range<ScalarT>& range)
     {
@@ -128,6 +134,8 @@ public:
 
 private:
     using RangeOfRanges = std::pair<ConstIterator, ConstIterator>;
+
+    [[nodiscard]]
     RangeOfRanges GetMergeableRanges(const Range<ScalarT>& range)
     {
         META_FUNCTION_TASK();

--- a/Modules/Data/RangeSet/Include/Methane/Data/RangeSet.hpp
+++ b/Modules/Data/RangeSet/Include/Methane/Data/RangeSet.hpp
@@ -106,25 +106,22 @@ public:
             
             if (range_it->Contains(range))
             {
-                const Range<ScalarT> left_sub_range(range_it->GetStart(), range.GetStart());
-                if (!left_sub_range.IsEmpty())
+                if (const Range<ScalarT> left_sub_range(range_it->GetStart(), range.GetStart());
+                    !left_sub_range.IsEmpty())
                 {
                     add_ranges.emplace_back(left_sub_range);
                 }
 
-                const Range<ScalarT> right_sub_range(range.GetEnd(), range_it->GetEnd());
-                if (!right_sub_range.IsEmpty())
+                if (const Range<ScalarT> right_sub_range(range.GetEnd(), range_it->GetEnd());
+                    !right_sub_range.IsEmpty())
                 {
                     add_ranges.emplace_back(right_sub_range);
                 }
             }
-            else
+            else if (Range<ScalarT> trimmed_range = *range_it - range;
+                    !trimmed_range.IsEmpty())
             {
-                Range<ScalarT> trimmed_range = *range_it - range;
-                if (!trimmed_range.IsEmpty())
-                {
-                    add_ranges.emplace_back(trimmed_range);
-                }
+                add_ranges.emplace_back(trimmed_range);
             }
         }
 

--- a/Modules/Data/Types/Include/Methane/Data/Chunk.hpp
+++ b/Modules/Data/Types/Include/Methane/Data/Chunk.hpp
@@ -51,11 +51,11 @@ public:
 
     ~Chunk() = default;
 
-    ConstRawPtr GetDataPtr() const noexcept    { return m_data_ptr; }
-    ConstRawPtr GetDataEndPtr() const noexcept { return m_data_ptr + m_data_size; }
-    Size        GetDataSize() const noexcept   { return m_data_size; }
-    bool        IsEmptyOrNull() const noexcept { return !m_data_ptr || !m_data_size; }
-    bool        IsDataStored() const noexcept  { return !m_data_storage.empty(); }
+    [[nodiscard]] ConstRawPtr GetDataPtr() const noexcept    { return m_data_ptr; }
+    [[nodiscard]] ConstRawPtr GetDataEndPtr() const noexcept { return m_data_ptr + m_data_size; }
+    [[nodiscard]] Size        GetDataSize() const noexcept   { return m_data_size; }
+    [[nodiscard]] bool        IsEmptyOrNull() const noexcept { return !m_data_ptr || !m_data_size; }
+    [[nodiscard]] bool        IsDataStored() const noexcept  { return !m_data_storage.empty(); }
 
 protected:
     explicit Chunk(const Chunk& other) noexcept

--- a/Modules/Data/Types/Include/Methane/Data/TimeRange.hpp
+++ b/Modules/Data/Types/Include/Methane/Data/TimeRange.hpp
@@ -33,16 +33,19 @@ using TimeRange = Range<Timestamp>;
 
 constexpr Timestamp g_one_sec_in_nanoseconds = 1000000000;
 
+[[nodiscard]]
 inline Timestamp ConvertTimeSecondsToNanoseconds(double seconds)
 {
     return static_cast<Timestamp>(seconds * g_one_sec_in_nanoseconds);
 }
 
+[[nodiscard]]
 inline Timestamp ConvertTicksToNanoseconds(Timestamp ticks, Frequency frequency)
 {
     return ticks * g_one_sec_in_nanoseconds / frequency;
 }
 
+[[nodiscard]]
 inline float ConvertFrequencyToTickPeriod(Frequency frequency)
 {
     return static_cast<float>(g_one_sec_in_nanoseconds) / frequency;

--- a/Modules/Data/Types/Include/Methane/Data/Types.h
+++ b/Modules/Data/Types/Include/Methane/Data/Types.h
@@ -27,6 +27,7 @@ u
 #include "Rect.hpp"
 
 #include <cstdint>
+#include <cstddef>
 #include <vector>
 
 namespace Methane::Data
@@ -41,10 +42,11 @@ enum class MemoryState : uint32_t
 using Timestamp = uint64_t;
 using TimeDelta = int64_t;
 using Frequency = Timestamp;
-using Bytes = std::vector<uint8_t>;
+using Byte = std::byte;
+using Bytes = std::vector<std::byte>;
 using Size = uint32_t;
 using Index = Size;
-using RawPtr = uint8_t*;
-using ConstRawPtr = const uint8_t*;
+using RawPtr = Byte*;
+using ConstRawPtr = const Byte*;
 
 } // namespace Methane::Data

--- a/Modules/Graphics/App/Sources/Methane/Graphics/AppBase.cpp
+++ b/Modules/Graphics/App/Sources/Methane/Graphics/AppBase.cpp
@@ -229,6 +229,7 @@ Ptr<RenderPass> AppBase::CreateScreenRenderPass(const Ptr<Texture>& frame_buffer
     META_CHECK_ARG_NOT_NULL(frame_buffer_texture);
 
     const RenderContext::Settings& context_settings = m_context_ptr->GetSettings();
+    static constexpr DepthStencil s_default_depth_stencil{ Depth(1.F), Stencil(0) };
 
     return RenderPass::Create(*m_context_ptr, {
         {
@@ -240,9 +241,7 @@ Ptr<RenderPass> AppBase::CreateScreenRenderPass(const Ptr<Texture>& frame_buffer
                         : RenderPass::Attachment::LoadAction::DontCare,
                     RenderPass::Attachment::StoreAction::Store,
                 },
-                context_settings.clear_color
-                    ? *context_settings.clear_color
-                    : Color4f()
+                context_settings.clear_color.value_or(Color4f())
             )
         },
         RenderPass::DepthAttachment(
@@ -253,9 +252,7 @@ Ptr<RenderPass> AppBase::CreateScreenRenderPass(const Ptr<Texture>& frame_buffer
                     : RenderPass::Attachment::LoadAction::DontCare,
                 RenderPass::Attachment::StoreAction::DontCare,
             },
-            context_settings.clear_depth_stencil
-                ? context_settings.clear_depth_stencil->first
-                : 1.F
+            context_settings.clear_depth_stencil.value_or(s_default_depth_stencil).first
         ),
         RenderPass::StencilAttachment(),
         m_settings.screen_pass_access,

--- a/Modules/Graphics/App/Sources/Methane/Graphics/AppCameraController.cpp
+++ b/Modules/Graphics/App/Sources/Methane/Graphics/AppCameraController.cpp
@@ -84,14 +84,14 @@ AppCameraController::HelpLines AppCameraController::GetHelp() const
     const HelpLines mouse_help_lines = GetMouseHelp();
     if (!mouse_help_lines.empty())
     {
-        help_lines.push_back({ "", "Mouse actions" });
+        help_lines.emplace_back("", "Mouse actions");
         help_lines.insert(help_lines.end(), mouse_help_lines.begin(), mouse_help_lines.end());
     }
 
     const HelpLines keyboard_help_lines = GetKeyboardHelp();
     if (!keyboard_help_lines.empty())
     {
-        help_lines.push_back({ "", "Keyboard actions" });
+        help_lines.emplace_back("", "Keyboard actions");
         help_lines.insert(help_lines.end(), keyboard_help_lines.begin(), keyboard_help_lines.end());
     }
     

--- a/Modules/Graphics/App/Sources/Methane/Graphics/AppCameraController.cpp
+++ b/Modules/Graphics/App/Sources/Methane/Graphics/AppCameraController.cpp
@@ -61,11 +61,11 @@ void AppCameraController::OnMousePositionChanged(const Platform::Mouse::Position
 void AppCameraController::OnMouseScrollChanged(const Platform::Mouse::Scroll& mouse_scroll_delta, const Platform::Mouse::StateChange&)
 {
     META_FUNCTION_TASK();
-    const auto mouse_button_and_delta = Platform::Mouse::GetScrollButtonAndDelta(mouse_scroll_delta);
-    const ActionCamera::MouseAction action = GetMouseActionByButton(mouse_button_and_delta.first);
+    const auto [mouse_button, scroll_delta] = Platform::Mouse::GetScrollButtonAndDelta(mouse_scroll_delta);
+    const ActionCamera::MouseAction action = GetMouseActionByButton(mouse_button);
     if (action == ActionCamera::MouseAction::Zoom)
     {
-        m_action_camera.OnMouseScrolled(mouse_button_and_delta.second);
+        m_action_camera.OnMouseScrolled(scroll_delta);
     }
 }
 

--- a/Modules/Graphics/App/Sources/Methane/Graphics/AppCameraController.cpp
+++ b/Modules/Graphics/App/Sources/Methane/Graphics/AppCameraController.cpp
@@ -62,8 +62,8 @@ void AppCameraController::OnMouseScrollChanged(const Platform::Mouse::Scroll& mo
 {
     META_FUNCTION_TASK();
     const auto [mouse_button, scroll_delta] = Platform::Mouse::GetScrollButtonAndDelta(mouse_scroll_delta);
-    const ActionCamera::MouseAction action = GetMouseActionByButton(mouse_button);
-    if (action == ActionCamera::MouseAction::Zoom)
+    if (const ActionCamera::MouseAction action = GetMouseActionByButton(mouse_button);
+        action == ActionCamera::MouseAction::Zoom)
     {
         m_action_camera.OnMouseScrolled(scroll_delta);
     }
@@ -81,15 +81,15 @@ AppCameraController::HelpLines AppCameraController::GetHelp() const
     HelpLines help_lines;
     help_lines.reserve(GetMouseActionsCount() + GetKeyboardActionsCount() + 2);
 
-    const HelpLines mouse_help_lines = GetMouseHelp();
-    if (!mouse_help_lines.empty())
+    if (const HelpLines mouse_help_lines = GetMouseHelp();
+        !mouse_help_lines.empty())
     {
         help_lines.emplace_back("", "Mouse actions");
         help_lines.insert(help_lines.end(), mouse_help_lines.begin(), mouse_help_lines.end());
     }
 
-    const HelpLines keyboard_help_lines = GetKeyboardHelp();
-    if (!keyboard_help_lines.empty())
+    if (const HelpLines keyboard_help_lines = GetKeyboardHelp();
+        !keyboard_help_lines.empty())
     {
         help_lines.emplace_back("", "Keyboard actions");
         help_lines.insert(help_lines.end(), keyboard_help_lines.begin(), keyboard_help_lines.end());

--- a/Modules/Graphics/App/Sources/Methane/Graphics/AppContextController.cpp
+++ b/Modules/Graphics/App/Sources/Methane/Graphics/AppContextController.cpp
@@ -96,10 +96,10 @@ void AppContextController::ResetContextWithNextDevice()
 {
     META_FUNCTION_TASK();
     const Ptr<Device> next_device_ptr = System::Get().GetNextGpuDevice(m_context.GetDevice());
-    if (next_device_ptr)
-    {
-        m_context.Reset(*next_device_ptr);
-    }
+    if (!next_device_ptr)
+        return;
+
+    m_context.Reset(*next_device_ptr);
 }
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Camera/Sources/Methane/Graphics/ActionCamera.cpp
+++ b/Modules/Graphics/Camera/Sources/Methane/Graphics/ActionCamera.cpp
@@ -189,9 +189,9 @@ void ActionCamera::StartRotateAction(KeyboardAction rotate_action, const Vector3
                 return true;
             },
             duration_sec));
-    
-    const auto emplace_result = m_keyboard_action_animations.emplace(rotate_action, m_animations.back());
-    META_CHECK_ARG_TRUE(emplace_result.second);
+
+    const bool animation_added = m_keyboard_action_animations.try_emplace(rotate_action, m_animations.back()).second;
+    META_CHECK_ARG_TRUE(animation_added);
 }
 
 void ActionCamera::StartMoveAction(KeyboardAction move_action, const Vector3f& move_direction_in_view, double duration_sec)
@@ -209,9 +209,9 @@ void ActionCamera::StartMoveAction(KeyboardAction move_action, const Vector3f& m
             },
             duration_sec)
     );
-    
-    const auto emplace_result = m_keyboard_action_animations.emplace(move_action, m_animations.back());
-    META_CHECK_ARG_TRUE(emplace_result.second);
+
+    const bool animation_added = m_keyboard_action_animations.try_emplace(move_action, m_animations.back()).second;
+    META_CHECK_ARG_TRUE(animation_added);
 }
 
 void ActionCamera::StartZoomAction(KeyboardAction zoom_action, float zoom_factor_per_second, double duration_sec)
@@ -228,9 +228,9 @@ void ActionCamera::StartZoomAction(KeyboardAction zoom_action, float zoom_factor
             },
             duration_sec)
     );
-    
-    const auto emplace_result = m_keyboard_action_animations.emplace(zoom_action, m_animations.back());
-    META_CHECK_ARG_TRUE(emplace_result.second);
+
+    const bool animation_added = m_keyboard_action_animations.try_emplace(zoom_action, m_animations.back()).second;
+    META_CHECK_ARG_TRUE(animation_added);
 }
 
 bool ActionCamera::StartKeyboardAction(KeyboardAction keyboard_action, double duration_sec)

--- a/Modules/Graphics/Camera/Sources/Methane/Graphics/ArcBallCamera.cpp
+++ b/Modules/Graphics/Camera/Sources/Methane/Graphics/ArcBallCamera.cpp
@@ -107,8 +107,8 @@ Vector3f ArcBallCamera::GetNormalizedSphereProjection(const Point2i& mouse_scree
     float z_sign = 1.F;
     if (!is_primary && inside_sphere && screen_radius > sphere_radius)
     {
-        const auto radius_mult = static_cast<uint32_t>(std::floor(screen_radius / sphere_radius));
-        if (radius_mult < 2)
+        if (const auto radius_mult = static_cast<uint32_t>(std::floor(screen_radius / sphere_radius));
+            radius_mult < 2)
         {
             const float vector_radius = sphere_radius * static_cast<float>(radius_mult + 1) - screen_radius;
             screen_point = screen_point.Normalize() * vector_radius;

--- a/Modules/Graphics/Camera/Sources/Methane/Graphics/ArcBallCamera.cpp
+++ b/Modules/Graphics/Camera/Sources/Methane/Graphics/ArcBallCamera.cpp
@@ -33,7 +33,10 @@ Arc-ball camera rotation with mouse handling.
 namespace Methane::Graphics
 {
 
+[[nodiscard]]
 static inline float Square(float x)     { return x * x; }
+
+[[nodiscard]]
 static inline float UnitSign(float x)   { return x / std::fabs(x); }
 
 ArcBallCamera::ArcBallCamera(Pivot pivot, cml::AxisOrientation axis_orientation) noexcept

--- a/Modules/Graphics/Core/Include/Methane/Graphics/BlitCommandList.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/BlitCommandList.h
@@ -33,7 +33,7 @@ namespace Methane::Graphics
 struct BlitCommandList : virtual CommandList
 {
     // Create BlitCommandList instance
-    static Ptr<BlitCommandList> Create(CommandQueue& command_queue);
+    [[nodiscard]] static Ptr<BlitCommandList> Create(CommandQueue& command_queue);
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Buffer.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Buffer.h
@@ -58,29 +58,29 @@ struct Buffer : virtual Resource
     };
 
     // Create Buffer instance
-    static Ptr<Buffer> CreateVertexBuffer(Context& context, Data::Size size, Data::Size stride);
-    static Ptr<Buffer> CreateIndexBuffer(Context& context, Data::Size size, PixelFormat format);
-    static Ptr<Buffer> CreateConstantBuffer(Context& context, Data::Size size, bool addressable = false, const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
-    static Ptr<Buffer> CreateVolatileBuffer(Context& context, Data::Size size, bool addressable = false, const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
-    static Ptr<Buffer> CreateReadBackBuffer(Context& context, Data::Size size);
+    [[nodiscard]] static Ptr<Buffer> CreateVertexBuffer(Context& context, Data::Size size, Data::Size stride);
+    [[nodiscard]] static Ptr<Buffer> CreateIndexBuffer(Context& context, Data::Size size, PixelFormat format);
+    [[nodiscard]] static Ptr<Buffer> CreateConstantBuffer(Context& context, Data::Size size, bool addressable = false, const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
+    [[nodiscard]] static Ptr<Buffer> CreateVolatileBuffer(Context& context, Data::Size size, bool addressable = false, const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
+    [[nodiscard]] static Ptr<Buffer> CreateReadBackBuffer(Context& context, Data::Size size);
 
     // Auxiliary functions
-    static Data::Size  GetAlignedBufferSize(Data::Size size) noexcept;
+    [[nodiscard]] static Data::Size  GetAlignedBufferSize(Data::Size size) noexcept;
 
     // Buffer interface
-    virtual const Settings& GetSettings() const noexcept = 0;
-    virtual uint32_t        GetFormattedItemsCount() const noexcept = 0;
+    [[nodiscard]] virtual const Settings& GetSettings() const noexcept = 0;
+    [[nodiscard]] virtual uint32_t        GetFormattedItemsCount() const noexcept = 0;
 };
 
 struct BufferSet
 {
-    static Ptr<BufferSet> Create(Buffer::Type buffers_type, const Refs<Buffer>& buffer_refs);
-    static Ptr<BufferSet> CreateVertexBuffers(const Refs<Buffer>& buffer_refs) { return BufferSet::Create(Buffer::Type::Vertex, buffer_refs); }
+    [[nodiscard]] static Ptr<BufferSet> Create(Buffer::Type buffers_type, const Refs<Buffer>& buffer_refs);
+    [[nodiscard]] static Ptr<BufferSet> CreateVertexBuffers(const Refs<Buffer>& buffer_refs) { return BufferSet::Create(Buffer::Type::Vertex, buffer_refs); }
 
-    virtual Buffer::Type        GetType() const noexcept = 0;
-    virtual Data::Size          GetCount() const noexcept = 0;
-    virtual const Refs<Buffer>& GetRefs() const noexcept = 0;
-    virtual Buffer&             operator[](Data::Index index) const = 0;
+    [[nodiscard]] virtual Buffer::Type        GetType() const noexcept = 0;
+    [[nodiscard]] virtual Data::Size          GetCount() const noexcept = 0;
+    [[nodiscard]] virtual const Refs<Buffer>& GetRefs() const noexcept = 0;
+    [[nodiscard]] virtual Buffer&             operator[](Data::Index index) const = 0;
 
     virtual ~BufferSet() = default;
 };

--- a/Modules/Graphics/Core/Include/Methane/Graphics/CommandList.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/CommandList.h
@@ -56,18 +56,18 @@ struct CommandList : virtual Object
 
     struct DebugGroup : virtual Object
     {
-        static Ptr<DebugGroup> Create(const std::string& name);
+        [[nodiscard]] static Ptr<DebugGroup> Create(const std::string& name);
 
         virtual DebugGroup& AddSubGroup(Data::Index id, const std::string& name) = 0;
-        virtual DebugGroup* GetSubGroup(Data::Index id) const noexcept = 0;
-        virtual bool        HasSubGroups() const noexcept = 0;
+        [[nodiscard]] virtual DebugGroup* GetSubGroup(Data::Index id) const noexcept = 0;
+        [[nodiscard]] virtual bool        HasSubGroups() const noexcept = 0;
     };
 
     using CompletedCallback = std::function<void(CommandList& command_list)>;
 
     // CommandList interface
-    virtual Type  GetType() const noexcept = 0;
-    virtual State GetState() const noexcept = 0;
+    [[nodiscard]] virtual Type  GetType() const noexcept = 0;
+    [[nodiscard]] virtual State GetState() const noexcept = 0;
     virtual void  PushDebugGroup(DebugGroup& debug_group) = 0;
     virtual void  PopDebugGroup() = 0;
     virtual void  Reset(DebugGroup* p_debug_group = nullptr) = 0;
@@ -75,17 +75,17 @@ struct CommandList : virtual Object
                                      ProgramBindings::ApplyBehavior apply_behavior = ProgramBindings::ApplyBehavior::AllIncremental) = 0;
     virtual void  Commit() = 0;
     virtual void  WaitUntilCompleted(uint32_t timeout_ms = 0U) = 0;
-    virtual Data::TimeRange GetGpuTimeRange(bool in_cpu_nanoseconds) const = 0;
-    virtual CommandQueue& GetCommandQueue() = 0;
+    [[nodiscard]] virtual Data::TimeRange GetGpuTimeRange(bool in_cpu_nanoseconds) const = 0;
+    [[nodiscard]] virtual CommandQueue& GetCommandQueue() = 0;
 };
 
 struct CommandListSet
 {
-    static Ptr<CommandListSet> Create(const Refs<CommandList>& command_list_refs);
+    [[nodiscard]] static Ptr<CommandListSet> Create(const Refs<CommandList>& command_list_refs);
 
-    virtual Data::Size               GetCount() const noexcept = 0;
-    virtual const Refs<CommandList>& GetRefs() const noexcept = 0;
-    virtual CommandList&             operator[](Data::Index index) const = 0;
+    [[nodiscard]] virtual Data::Size               GetCount() const noexcept = 0;
+    [[nodiscard]] virtual const Refs<CommandList>& GetRefs() const noexcept = 0;
+    [[nodiscard]] virtual CommandList&             operator[](Data::Index index) const = 0;
 
     virtual ~CommandListSet() = default;
 };

--- a/Modules/Graphics/Core/Include/Methane/Graphics/CommandList.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/CommandList.h
@@ -71,6 +71,7 @@ struct CommandList : virtual Object
     virtual void  PushDebugGroup(DebugGroup& debug_group) = 0;
     virtual void  PopDebugGroup() = 0;
     virtual void  Reset(DebugGroup* p_debug_group = nullptr) = 0;
+    virtual void  ResetOnce(DebugGroup* p_debug_group = nullptr) = 0;
     virtual void  SetProgramBindings(ProgramBindings& program_bindings,
                                      ProgramBindings::ApplyBehavior apply_behavior = ProgramBindings::ApplyBehavior::AllIncremental) = 0;
     virtual void  Commit() = 0;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/CommandQueue.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/CommandQueue.h
@@ -35,10 +35,10 @@ namespace Methane::Graphics
 struct CommandQueue : virtual Object
 {
     // Create CommandQueue instance
-    static Ptr<CommandQueue> Create(Context& context, CommandList::Type command_lists_type);
+    [[nodiscard]] static Ptr<CommandQueue> Create(Context& context, CommandList::Type command_lists_type);
 
     // CommandQueue interface
-    virtual CommandList::Type GetCommandListsType() const noexcept = 0;
+    [[nodiscard]] virtual CommandList::Type GetCommandListsType() const noexcept = 0;
     virtual void Execute(CommandListSet& command_lists, const CommandList::CompletedCallback& completed_callback = {}) = 0;
 };
 

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Context.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Context.h
@@ -29,7 +29,7 @@ Methane base context interface: wraps graphics device used for GPU interaction.
 #include <Methane/Graphics/Types.h>
 #include <Methane/Data/IEmitter.h>
 
-namespace tf
+namespace tf // NOSONAR
 {
 // TaskFlow Executor class forward declaration:
 // #include <taskflow/core/executor.hpp>
@@ -78,20 +78,20 @@ struct Context
     };
 
     // Context interface
-    virtual Type GetType() const noexcept = 0;
-    virtual tf::Executor& GetParallelExecutor() const noexcept = 0;
-    virtual Object::Registry& GetObjectsRegistry() noexcept = 0;
+    [[nodiscard]] virtual Type GetType() const noexcept = 0;
+    [[nodiscard]] virtual tf::Executor& GetParallelExecutor() const noexcept = 0;
+    [[nodiscard]] virtual Object::Registry& GetObjectsRegistry() noexcept = 0;
     virtual void RequestDeferredAction(DeferredAction action) const noexcept = 0;
     virtual void CompleteInitialization() = 0;
-    virtual bool IsCompletingInitialization() const noexcept = 0;
+    [[nodiscard]] virtual bool IsCompletingInitialization() const noexcept = 0;
     virtual void WaitForGpu(WaitFor wait_for) = 0;
     virtual void Reset(Device& device) = 0;
     virtual void Reset() = 0;
 
-    virtual Device&          GetDevice() = 0;
-    virtual CommandQueue&    GetUploadCommandQueue() = 0;
-    virtual BlitCommandList& GetUploadCommandList() = 0;
-    virtual CommandListSet&  GetUploadCommandListSet() = 0;
+    [[nodiscard]] virtual Device&          GetDevice() = 0;
+    [[nodiscard]] virtual CommandQueue&    GetUploadCommandQueue() = 0;
+    [[nodiscard]] virtual BlitCommandList& GetUploadCommandList() = 0;
+    [[nodiscard]] virtual CommandListSet&  GetUploadCommandListSet() = 0;
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Device.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Device.h
@@ -57,23 +57,23 @@ struct Device
         All                     = ~0U,
     };
 
-    virtual const std::string& GetAdapterName() const noexcept = 0;
-    virtual bool               IsSoftwareAdapter() const noexcept = 0;
-    virtual Features           GetSupportedFeatures() const noexcept = 0;
-    virtual std::string        ToString() const = 0;
+    [[nodiscard]] virtual const std::string& GetAdapterName() const noexcept = 0;
+    [[nodiscard]] virtual bool               IsSoftwareAdapter() const noexcept = 0;
+    [[nodiscard]] virtual Features           GetSupportedFeatures() const noexcept = 0;
+    [[nodiscard]] virtual std::string        ToString() const = 0;
 };
 
 struct System
 {
-    static System& Get();
+    [[nodiscard]] static System& Get();
 
-    virtual void                CheckForChanges() = 0;
-    virtual const Ptrs<Device>& UpdateGpuDevices(Device::Features supported_features = Device::Features::All) = 0;
-    virtual const Ptrs<Device>& GetGpuDevices() const = 0;
-    virtual Ptr<Device>         GetNextGpuDevice(const Device& device) const = 0;
-    virtual Ptr<Device>         GetSoftwareGpuDevice() const = 0;
-    virtual Device::Features    GetGpuSupportedFeatures() const = 0;
-    virtual std::string         ToString() const = 0;
+    virtual void CheckForChanges() = 0;
+    [[nodiscard]] virtual const Ptrs<Device>& UpdateGpuDevices(Device::Features supported_features = Device::Features::All) = 0;
+    [[nodiscard]] virtual const Ptrs<Device>& GetGpuDevices() const = 0;
+    [[nodiscard]] virtual Ptr<Device>         GetNextGpuDevice(const Device& device) const = 0;
+    [[nodiscard]] virtual Ptr<Device>         GetSoftwareGpuDevice() const = 0;
+    [[nodiscard]] virtual Device::Features    GetGpuSupportedFeatures() const = 0;
+    [[nodiscard]] virtual std::string         ToString() const = 0;
     
     virtual ~System() = default;
 };

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Fence.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Fence.h
@@ -34,7 +34,7 @@ struct CommandQueue;
 
 struct Fence : virtual Object
 {
-    static Ptr<Fence> Create(CommandQueue& command_queue);
+    [[nodiscard]] static Ptr<Fence> Create(CommandQueue& command_queue);
 
     // Fence interface
     virtual void Signal() = 0;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Object.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Object.h
@@ -40,17 +40,17 @@ struct Object
             explicit NameConflictException(const std::string& name);
         };
 
-        virtual void        AddGraphicsObject(Object& graphics_object) = 0;
-        virtual Ptr<Object> GetGraphicsObject(const std::string& object_name) const noexcept = 0;
-        virtual bool        HasGraphicsObject(const std::string& object_name) const noexcept = 0;
+        virtual void AddGraphicsObject(Object& graphics_object) = 0;
+        [[nodiscard]] virtual Ptr<Object> GetGraphicsObject(const std::string& object_name) const noexcept = 0;
+        [[nodiscard]] virtual bool        HasGraphicsObject(const std::string& object_name) const noexcept = 0;
 
         virtual ~Registry() = default;
     };
 
     // Object interface
-    virtual void               SetName(const std::string& name) = 0;
-    virtual const std::string& GetName() const noexcept = 0;
-    virtual Ptr<Object>        GetPtr() = 0;
+    virtual void SetName(const std::string& name) = 0;
+    [[nodiscard]] virtual const std::string& GetName() const noexcept = 0;
+    [[nodiscard]] virtual Ptr<Object>        GetPtr() = 0;
 
     virtual ~Object() = default;
 };

--- a/Modules/Graphics/Core/Include/Methane/Graphics/ParallelRenderCommandList.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/ParallelRenderCommandList.h
@@ -42,7 +42,7 @@ struct ParallelRenderCommandList : virtual CommandList
     // ParallelRenderCommandList interface
     [[nodiscard]] virtual bool IsValidationEnabled() const noexcept = 0;
     virtual void SetValidationEnabled(bool is_validation_enabled) = 0;
-    virtual void ResetWithState(const Ptr<RenderState>& render_state_ptr = nullptr, DebugGroup* p_debug_group = nullptr) = 0;
+    virtual void ResetWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) = 0;
     virtual void SetViewState(ViewState& view_state) = 0;
     virtual void SetParallelCommandListsCount(uint32_t count) = 0;
     [[nodiscard]] virtual const Ptrs<RenderCommandList>& GetParallelCommandLists() const = 0;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/ParallelRenderCommandList.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/ParallelRenderCommandList.h
@@ -37,15 +37,15 @@ struct RenderPass;
 struct ParallelRenderCommandList : virtual CommandList
 {
     // Create ParallelRenderCommandList instance
-    static Ptr<ParallelRenderCommandList> Create(CommandQueue& command_queue, RenderPass& render_pass);
+    [[nodiscard]] static Ptr<ParallelRenderCommandList> Create(CommandQueue& command_queue, RenderPass& render_pass);
     
     // ParallelRenderCommandList interface
-    virtual bool IsValidationEnabled() const noexcept = 0;
+    [[nodiscard]] virtual bool IsValidationEnabled() const noexcept = 0;
     virtual void SetValidationEnabled(bool is_validation_enabled) = 0;
     virtual void ResetWithState(const Ptr<RenderState>& render_state_ptr = nullptr, DebugGroup* p_debug_group = nullptr) = 0;
     virtual void SetViewState(ViewState& view_state) = 0;
     virtual void SetParallelCommandListsCount(uint32_t count) = 0;
-    virtual const Ptrs<RenderCommandList>& GetParallelCommandLists() const = 0;
+    [[nodiscard]] virtual const Ptrs<RenderCommandList>& GetParallelCommandLists() const = 0;
     
     using CommandList::Reset;
 };

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Program.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Program.h
@@ -71,8 +71,8 @@ struct Program : virtual Object
         public:
             NotFoundException(const Program& program, const Argument& argument);
 
-            const Program&  GetProgram() const noexcept  { return m_program; }
-            const Argument& GetArgument() const noexcept { return *m_argument_ptr; }
+            [[nodiscard]] const Program&  GetProgram() const noexcept  { return m_program; }
+            [[nodiscard]] const Argument& GetArgument() const noexcept { return *m_argument_ptr; }
 
         private:
             const Program& m_program;
@@ -95,12 +95,12 @@ struct Program : virtual Object
         Argument(const Argument& argument) = default;
         Argument(Argument&& argument) noexcept = default;
 
-        bool operator==(const Argument& other) const noexcept;
-        explicit operator std::string() const noexcept;
+        [[nodiscard]] bool operator==(const Argument& other) const noexcept;
+        [[nodiscard]] explicit operator std::string() const noexcept;
 
         struct Hash
         {
-            size_t operator()(const Argument& arg) const { return arg.hash; }
+            [[nodiscard]] size_t operator()(const Argument& arg) const { return arg.hash; }
         };
     };
 
@@ -117,8 +117,8 @@ struct Program : virtual Object
         ArgumentDesc(const ArgumentDesc& argument_desc) = default;
         ArgumentDesc(ArgumentDesc&& argument_desc) noexcept = default;
 
-        inline bool IsConstant() const    { using namespace magic_enum::bitwise_operators; return magic_enum::flags::enum_contains(modifiers & Modifiers::Constant); }
-        inline bool IsAddressable() const { using namespace magic_enum::bitwise_operators; return magic_enum::flags::enum_contains(modifiers & Modifiers::Addressable); }
+        [[nodiscard]] inline bool IsConstant() const    { using namespace magic_enum::bitwise_operators; return magic_enum::flags::enum_contains(modifiers & Modifiers::Constant); }
+        [[nodiscard]] inline bool IsAddressable() const { using namespace magic_enum::bitwise_operators; return magic_enum::flags::enum_contains(modifiers & Modifiers::Addressable); }
     };
 
     using ArgumentDescriptions = std::unordered_set<ArgumentDesc, ArgumentDesc::Hash>;
@@ -136,12 +136,12 @@ struct Program : virtual Object
     };
 
     // Create Program instance
-    static Ptr<Program> Create(Context& context, const Settings& settings);
+    [[nodiscard]] static Ptr<Program> Create(Context& context, const Settings& settings);
 
     // Program interface
-    virtual const Settings&      GetSettings() const = 0;
-    virtual const Shader::Types& GetShaderTypes() const = 0;
-    virtual const Ptr<Shader>&   GetShader(Shader::Type shader_type) const = 0;
+    [[nodiscard]] virtual const Settings&      GetSettings() const = 0;
+    [[nodiscard]] virtual const Shader::Types& GetShaderTypes() const = 0;
+    [[nodiscard]] virtual const Ptr<Shader>&   GetShader(Shader::Type shader_type) const = 0;
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Include/Methane/Graphics/ProgramBindings.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/ProgramBindings.h
@@ -54,9 +54,9 @@ struct ProgramBindings
         };
 
         // ArgumentBinding interface
-        virtual const Settings&            GetSettings() const noexcept = 0;
-        virtual const Resource::Locations& GetResourceLocations() const noexcept = 0;
-        virtual void                       SetResourceLocations(const Resource::Locations& resource_locations) = 0;
+        [[nodiscard]] virtual const Settings&            GetSettings() const noexcept = 0;
+        [[nodiscard]] virtual const Resource::Locations& GetResourceLocations() const noexcept = 0;
+        virtual void SetResourceLocations(const Resource::Locations& resource_locations) = 0;
 
         virtual ~ArgumentBinding() = default;
     };
@@ -79,8 +79,8 @@ struct ProgramBindings
     public:
         UnboundArgumentsException(const Program& program, const Program::Arguments& unbound_arguments);
 
-        const Program& GetProgram() const noexcept { return m_program; }
-        const Program::Arguments& GetArguments() const noexcept { return m_unbound_arguments; }
+        [[nodiscard]] const Program& GetProgram() const noexcept { return m_program; }
+        [[nodiscard]] const Program::Arguments& GetArguments() const noexcept { return m_unbound_arguments; }
 
     private:
         const Program& m_program;
@@ -88,11 +88,11 @@ struct ProgramBindings
     };
 
     // Create ProgramBindings instance
-    static Ptr<ProgramBindings> Create(const Ptr<Program>& program_ptr, const ResourceLocationsByArgument& resource_locations_by_argument);
-    static Ptr<ProgramBindings> CreateCopy(const ProgramBindings& other_program_bindings, const ResourceLocationsByArgument& replace_resource_locations_by_argument = {});
+    [[nodiscard]] static Ptr<ProgramBindings> Create(const Ptr<Program>& program_ptr, const ResourceLocationsByArgument& resource_locations_by_argument);
+    [[nodiscard]] static Ptr<ProgramBindings> CreateCopy(const ProgramBindings& other_program_bindings, const ResourceLocationsByArgument& replace_resource_locations_by_argument = {});
 
     // ProgramBindings interface
-    virtual const Ptr<ArgumentBinding>& Get(const Program::Argument& shader_argument) const = 0;
+    [[nodiscard]] virtual const Ptr<ArgumentBinding>& Get(const Program::Argument& shader_argument) const = 0;
 
     virtual ~ProgramBindings() = default;
 };

--- a/Modules/Graphics/Core/Include/Methane/Graphics/RenderCommandList.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/RenderCommandList.h
@@ -54,8 +54,8 @@ struct RenderCommandList : virtual CommandList
     [[nodiscard]] virtual bool IsValidationEnabled() const noexcept = 0;
     virtual void SetValidationEnabled(bool is_validation_enabled) = 0;
     [[nodiscard]] virtual RenderPass& GetRenderPass() const noexcept = 0;
-    virtual void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) = 0;
-    virtual void ResetOnceWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) = 0;
+    virtual void ResetWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) = 0;
+    virtual void ResetOnceWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) = 0;
     virtual void SetRenderState(RenderState& render_state, RenderState::Groups state_groups = RenderState::Groups::All) = 0;
     virtual void SetViewState(ViewState& view_state) = 0;
     virtual void SetVertexBuffers(BufferSet& vertex_buffers) = 0;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/RenderCommandList.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/RenderCommandList.h
@@ -55,6 +55,7 @@ struct RenderCommandList : virtual CommandList
     virtual void SetValidationEnabled(bool is_validation_enabled) = 0;
     [[nodiscard]] virtual RenderPass& GetRenderPass() const noexcept = 0;
     virtual void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) = 0;
+    virtual void ResetOnceWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) = 0;
     virtual void SetRenderState(RenderState& render_state, RenderState::Groups state_groups = RenderState::Groups::All) = 0;
     virtual void SetViewState(ViewState& view_state) = 0;
     virtual void SetVertexBuffers(BufferSet& vertex_buffers) = 0;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/RenderCommandList.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/RenderCommandList.h
@@ -47,13 +47,13 @@ struct RenderCommandList : virtual CommandList
     };
 
     // Create RenderCommandList instance
-    static Ptr<RenderCommandList> Create(CommandQueue& command_queue, RenderPass& render_pass);
-    static Ptr<RenderCommandList> Create(ParallelRenderCommandList& parallel_command_list);
+    [[nodiscard]] static Ptr<RenderCommandList> Create(CommandQueue& command_queue, RenderPass& render_pass);
+    [[nodiscard]] static Ptr<RenderCommandList> Create(ParallelRenderCommandList& parallel_command_list);
     
     // RenderCommandList interface
-    virtual bool IsValidationEnabled() const noexcept = 0;
+    [[nodiscard]] virtual bool IsValidationEnabled() const noexcept = 0;
     virtual void SetValidationEnabled(bool is_validation_enabled) = 0;
-    virtual RenderPass& GetRenderPass() const noexcept = 0;
+    [[nodiscard]] virtual RenderPass& GetRenderPass() const noexcept = 0;
     virtual void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) = 0;
     virtual void SetRenderState(RenderState& render_state, RenderState::Groups state_groups = RenderState::Groups::All) = 0;
     virtual void SetViewState(ViewState& view_state) = 0;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/RenderCommandList.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/RenderCommandList.h
@@ -55,7 +55,7 @@ struct RenderCommandList : virtual CommandList
     virtual void SetValidationEnabled(bool is_validation_enabled) = 0;
     [[nodiscard]] virtual RenderPass& GetRenderPass() const noexcept = 0;
     virtual void ResetWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) = 0;
-    virtual void ResetOnceWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) = 0;
+    virtual void ResetWithStateOnce(RenderState& render_state, DebugGroup* p_debug_group = nullptr) = 0;
     virtual void SetRenderState(RenderState& render_state, RenderState::Groups state_groups = RenderState::Groups::All) = 0;
     virtual void SetViewState(ViewState& view_state) = 0;
     virtual void SetVertexBuffers(BufferSet& vertex_buffers) = 0;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/RenderContext.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/RenderContext.h
@@ -57,21 +57,21 @@ struct RenderContext : virtual Context
     };
 
     // Create RenderContext instance
-    static Ptr<RenderContext> Create(const Platform::AppEnvironment& env, Device& device, tf::Executor& parallel_executor, const Settings& settings);
+    [[nodiscard]] static Ptr<RenderContext> Create(const Platform::AppEnvironment& env, Device& device, tf::Executor& parallel_executor, const Settings& settings);
 
     // RenderContext interface
-    virtual bool ReadyToRender() const = 0;
+    [[nodiscard]] virtual bool ReadyToRender() const = 0;
     virtual void Resize(const FrameSize& frame_size) = 0;
     virtual void Present() = 0;
 
-    virtual Platform::AppView GetAppView() const = 0;
-    virtual CommandQueue&     GetRenderCommandQueue() = 0;
-    virtual const Settings&   GetSettings() const noexcept = 0;
-    virtual uint32_t          GetFrameBufferIndex() const noexcept = 0;
-    virtual uint32_t          GetFrameIndex() const noexcept = 0;
-    virtual float             GetContentScalingFactor() const = 0;
-    virtual uint32_t          GetFontResolutionDpi() const = 0;
-    virtual const FpsCounter& GetFpsCounter() const noexcept = 0;
+    [[nodiscard]] virtual Platform::AppView GetAppView() const = 0;
+    [[nodiscard]] virtual CommandQueue&     GetRenderCommandQueue() = 0;
+    [[nodiscard]] virtual const Settings&   GetSettings() const noexcept = 0;
+    [[nodiscard]] virtual uint32_t          GetFrameBufferIndex() const noexcept = 0;
+    [[nodiscard]] virtual uint32_t          GetFrameIndex() const noexcept = 0;
+    [[nodiscard]] virtual float             GetContentScalingFactor() const = 0;
+    [[nodiscard]] virtual uint32_t          GetFontResolutionDpi() const = 0;
+    [[nodiscard]] virtual const FpsCounter& GetFpsCounter() const noexcept = 0;
 
     virtual bool SetVSyncEnabled(bool vsync_enabled) = 0;
     virtual bool SetFrameBuffersCount(uint32_t frame_buffers_count) = 0;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/RenderPass.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/RenderPass.h
@@ -58,17 +58,17 @@ struct RenderPass : virtual Object
         Texture::Location  texture_location;
         LoadAction         load_action  = LoadAction::DontCare;
         StoreAction        store_action = StoreAction::DontCare;
-        
-        bool operator==(const Attachment& other) const;
+
+        [[nodiscard]] bool operator==(const Attachment& other) const;
     };
     
     struct ColorAttachment : Attachment
     {
         Color4f clear_color;
         
-        ColorAttachment(const Attachment&& attach, const Color4f& in_clear_color = Color4f()) : Attachment(std::move(attach)), clear_color(in_clear_color) { }
-        
-        bool operator==(const ColorAttachment& other) const;
+        ColorAttachment(const Attachment& attach, const Color4f& in_clear_color = Color4f()) : Attachment(attach), clear_color(in_clear_color) { }
+
+        [[nodiscard]] bool operator==(const ColorAttachment& other) const;
     };
     
     using ColorAttachments = std::vector<ColorAttachment>;
@@ -78,9 +78,9 @@ struct RenderPass : virtual Object
         Depth clear_value = 1.F;
         
         DepthAttachment() = default;
-        DepthAttachment(const Attachment&& attach, Depth in_clear_value = 1.F) : Attachment(std::move(attach)), clear_value(in_clear_value) { }
-        
-        bool operator==(const DepthAttachment& other) const;
+        DepthAttachment(const Attachment& attach, Depth in_clear_value = 1.F) : Attachment(attach), clear_value(in_clear_value) { }
+
+        [[nodiscard]] bool operator==(const DepthAttachment& other) const;
     };
     
     struct StencilAttachment : Attachment
@@ -88,9 +88,9 @@ struct RenderPass : virtual Object
         Stencil clear_value = 0U;
         
         StencilAttachment() = default;
-        StencilAttachment(const Attachment&& attach, Stencil in_clear_value = 0U) : Attachment(std::move(attach)), clear_value(in_clear_value) { }
-        
-        bool operator==(const StencilAttachment& other) const;
+        StencilAttachment(const Attachment& attach, Stencil in_clear_value = 0U) : Attachment(attach), clear_value(in_clear_value) { }
+
+        [[nodiscard]] bool operator==(const StencilAttachment& other) const;
     };
 
     enum class Access : uint32_t
@@ -111,15 +111,15 @@ struct RenderPass : virtual Object
         Access             shader_access_mask = Access::None;
         bool               is_final_pass = true;
 
-        bool operator==(const Settings& other) const;
-        bool operator!=(const Settings& other) const;
+        [[nodiscard]] bool operator==(const Settings& other) const;
+        [[nodiscard]] bool operator!=(const Settings& other) const;
     };
 
     // Create RenderPass instance
-    static Ptr<RenderPass> Create(RenderContext& context, const Settings& settings);
+    [[nodiscard]] static Ptr<RenderPass> Create(RenderContext& context, const Settings& settings);
 
     // RenderPass interface
-    virtual const Settings& GetSettings() const = 0;
+    [[nodiscard]] virtual const Settings& GetSettings() const = 0;
     virtual bool Update(const Settings& settings) = 0;
     virtual void ReleaseAttachmentTextures() = 0;
 };

--- a/Modules/Graphics/Core/Include/Methane/Graphics/RenderState.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/RenderState.h
@@ -44,15 +44,15 @@ struct ViewState
         Viewports    viewports;
         ScissorRects scissor_rects;
 
-        bool operator==(const Settings& other) const noexcept { return viewports == other.viewports && scissor_rects == other.scissor_rects; }
-        bool operator!=(const Settings& other) const noexcept { return !operator==(other); }
+        [[nodiscard]] bool operator==(const Settings& other) const noexcept { return viewports == other.viewports && scissor_rects == other.scissor_rects; }
+        [[nodiscard]] bool operator!=(const Settings& other) const noexcept { return !operator==(other); }
     };
 
     // Create ViewState instance
-    static Ptr<ViewState> Create(const Settings& state_settings);
+    [[nodiscard]] static Ptr<ViewState> Create(const Settings& state_settings);
 
     // ViewState interface
-    virtual const Settings& GetSettings() const noexcept = 0;
+    [[nodiscard]] virtual const Settings& GetSettings() const noexcept = 0;
     virtual bool Reset(const Settings& settings) = 0;
     virtual bool SetViewports(const Viewports& viewports) = 0;
     virtual bool SetScissorRects(const ScissorRects& scissor_rects) = 0;
@@ -84,8 +84,8 @@ public:
         uint32_t sample_count               = 1;
         bool     alpha_to_coverage_enabled  = false;
 
-        bool operator==(const Rasterizer& other) const noexcept;
-        bool operator!=(const Rasterizer& other) const noexcept;
+        [[nodiscard]] bool operator==(const Rasterizer& other) const noexcept;
+        [[nodiscard]] bool operator!=(const Rasterizer& other) const noexcept;
     };
 
     struct Blending
@@ -151,8 +151,8 @@ public:
         bool                        is_independent = false;
         std::array<RenderTarget, 8> render_targets;
 
-        bool operator==(const Blending& other) const noexcept;
-        bool operator!=(const Blending& other) const noexcept;
+        [[nodiscard]] bool operator==(const Blending& other) const noexcept;
+        [[nodiscard]] bool operator!=(const Blending& other) const noexcept;
     };
     
     struct Depth
@@ -161,8 +161,8 @@ public:
         bool    write_enabled   = true;
         Compare compare         = Compare::Less;
 
-        bool operator==(const Depth& other) const noexcept;
-        bool operator!=(const Depth& other) const noexcept;
+        [[nodiscard]] bool operator==(const Depth& other) const noexcept;
+        [[nodiscard]] bool operator!=(const Depth& other) const noexcept;
     };
     
     struct Stencil
@@ -197,8 +197,8 @@ public:
         FaceOperations front_face;
         FaceOperations back_face;
 
-        bool operator==(const Stencil& other) const noexcept;
-        bool operator!=(const Stencil& other) const noexcept;
+        [[nodiscard]] bool operator==(const Stencil& other) const noexcept;
+        [[nodiscard]] bool operator!=(const Stencil& other) const noexcept;
     };
 
     enum class Groups : uint32_t
@@ -224,14 +224,14 @@ public:
         Blending     blending;
         Color4f      blending_color;
 
-        static Groups Compare(const Settings& left, const Settings& right, Groups compare_groups = Groups::All) noexcept;
+        [[nodiscard]] static Groups Compare(const Settings& left, const Settings& right, Groups compare_groups = Groups::All) noexcept;
     };
 
     // Create RenderState instance
-    static Ptr<RenderState> Create(RenderContext& context, const Settings& state_settings);
+    [[nodiscard]] static Ptr<RenderState> Create(RenderContext& context, const Settings& state_settings);
 
     // RenderState interface
-    virtual const Settings& GetSettings() const noexcept = 0;
+    [[nodiscard]] virtual const Settings& GetSettings() const noexcept = 0;
     virtual void Reset(const Settings& settings) = 0;
 };
 

--- a/Modules/Graphics/Core/Include/Methane/Graphics/RenderState.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/RenderState.h
@@ -225,6 +225,8 @@ public:
         Color4f      blending_color;
 
         [[nodiscard]] static Groups Compare(const Settings& left, const Settings& right, Groups compare_groups = Groups::All) noexcept;
+        [[nodiscard]] bool operator==(const Settings& other) const noexcept;
+        [[nodiscard]] bool operator!=(const Settings& other) const noexcept;
     };
 
     // Create RenderState instance

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Resource.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Resource.h
@@ -93,18 +93,18 @@ struct Resource : virtual Object
         public:
             explicit Count(Data::Size array_size  = 1U, Data::Size depth  = 1U, Data::Size mip_levels_count = 1U);
 
-            Data::Size GetDepth() const noexcept          { return m_depth; }
-            Data::Size GetArraySize() const noexcept      { return m_array_size; }
-            Data::Size GetMipLevelsCount() const noexcept { return m_mip_levels_count; }
-            Data::Size GetRawCount() const noexcept       { return m_depth * m_array_size * m_mip_levels_count; }
+            [[nodiscard]] Data::Size GetDepth() const noexcept          { return m_depth; }
+            [[nodiscard]] Data::Size GetArraySize() const noexcept      { return m_array_size; }
+            [[nodiscard]] Data::Size GetMipLevelsCount() const noexcept { return m_mip_levels_count; }
+            [[nodiscard]] Data::Size GetRawCount() const noexcept       { return m_depth * m_array_size * m_mip_levels_count; }
 
             void operator+=(const Index& other) noexcept;
-            bool operator==(const Count& other) const noexcept;
-            bool operator!=(const Count& other) const noexcept { return !operator==(other); }
-            bool operator<(const Count& other) const noexcept;
-            bool operator>=(const Count& other) const noexcept;
-            explicit operator Index() const noexcept;
-            explicit operator std::string() const noexcept;
+            [[nodiscard]] bool operator==(const Count& other) const noexcept;
+            [[nodiscard]] bool operator!=(const Count& other) const noexcept { return !operator==(other); }
+            [[nodiscard]] bool operator<(const Count& other) const noexcept;
+            [[nodiscard]] bool operator>=(const Count& other) const noexcept;
+            [[nodiscard]] explicit operator Index() const noexcept;
+            [[nodiscard]] explicit operator std::string() const noexcept;
 
         private:
             Data::Size m_depth;
@@ -122,19 +122,19 @@ struct Resource : virtual Object
 
             Index& operator=(const Index&) noexcept = default;
 
-            Data::Index GetDepthSlice() const noexcept { return m_depth_slice; }
-            Data::Index GetArrayIndex() const noexcept { return m_array_index; }
-            Data::Index GetMipLevel() const noexcept   { return m_mip_level; }
-            Data::Index GetRawIndex(const Count& count) const noexcept
+            [[nodiscard]] Data::Index GetDepthSlice() const noexcept { return m_depth_slice; }
+            [[nodiscard]] Data::Index GetArrayIndex() const noexcept { return m_array_index; }
+            [[nodiscard]] Data::Index GetMipLevel() const noexcept   { return m_mip_level; }
+            [[nodiscard]] Data::Index GetRawIndex(const Count& count) const noexcept
             { return (m_array_index * count.GetDepth() + m_depth_slice) * count.GetMipLevelsCount() + m_mip_level; }
 
-            bool operator==(const Index& other) const noexcept;
-            bool operator!=(const Index& other) const noexcept { return !operator==(other); }
-            bool operator<(const Index& other) const noexcept;
-            bool operator>=(const Index& other) const noexcept;
-            bool operator<(const Count& other) const noexcept;
-            bool operator>=(const Count& other) const noexcept;
-            explicit operator std::string() const noexcept;
+            [[nodiscard]] bool operator==(const Index& other) const noexcept;
+            [[nodiscard]] bool operator!=(const Index& other) const noexcept { return !operator==(other); }
+            [[nodiscard]] bool operator<(const Index& other) const noexcept;
+            [[nodiscard]] bool operator>=(const Index& other) const noexcept;
+            [[nodiscard]] bool operator<(const Count& other) const noexcept;
+            [[nodiscard]] bool operator>=(const Count& other) const noexcept;
+            [[nodiscard]] explicit operator std::string() const noexcept;
 
         private:
             Data::Index m_depth_slice;
@@ -148,10 +148,10 @@ struct Resource : virtual Object
         SubResource(Data::ConstRawPtr p_data, Data::Size size, const Index& index = Index(), BytesRangeOpt data_range = {}) noexcept;
         ~SubResource() = default;
 
-        const Index&         GetIndex() const noexcept             { return m_index; }
-        bool                 HasDataRange() const noexcept         { return m_data_range.has_value(); }
-        const BytesRange&    GetDataRange() const                  { return m_data_range.value(); }
-        const BytesRangeOpt& GetDataRangeOptional() const noexcept { return m_data_range; }
+        [[nodiscard]] const Index&         GetIndex() const noexcept             { return m_index; }
+        [[nodiscard]] bool                 HasDataRange() const noexcept         { return m_data_range.has_value(); }
+        [[nodiscard]] const BytesRange&    GetDataRange() const                  { return m_data_range.value(); }
+        [[nodiscard]] const BytesRangeOpt& GetDataRangeOptional() const noexcept { return m_data_range; }
 
     private:
         Index         m_index;
@@ -167,13 +167,13 @@ struct Resource : virtual Object
         Location(const Ptr<Resource>& resource_ptr, Data::Size offset = 0U) : Location(resource_ptr, SubResource::Index(), offset) { }
         Location(const Ptr<Resource>& resource_ptr, const SubResource::Index& subresource_index, Data::Size offset = 0U);
 
-        bool operator==(const Location& other) const noexcept;
+        [[nodiscard]] bool operator==(const Location& other) const noexcept;
 
-        bool                      IsInitialized() const noexcept       { return !!m_resource_ptr; }
-        const Ptr<Resource>&      GetResourcePtr() const noexcept      { return m_resource_ptr; }
-        Resource&                 GetResource() const;
-        const SubResource::Index& GetSubresourceIndex() const noexcept { return m_subresource_index; }
-        Data::Size                GetOffset() const noexcept           { return m_offset; }
+        [[nodiscard]] bool                      IsInitialized() const noexcept       { return !!m_resource_ptr; }
+        [[nodiscard]] const Ptr<Resource>&      GetResourcePtr() const noexcept      { return m_resource_ptr; }
+        [[nodiscard]] Resource&                 GetResource() const;
+        [[nodiscard]] const SubResource::Index& GetSubresourceIndex() const noexcept { return m_subresource_index; }
+        [[nodiscard]] Data::Size                GetOffset() const noexcept           { return m_offset; }
 
     private:
         Ptr<Resource>      m_resource_ptr;
@@ -193,16 +193,16 @@ struct Resource : virtual Object
     }
 
     // Resource interface
-    virtual void                      SetData(const SubResources& sub_resources) = 0;
-    virtual SubResource               GetData(const SubResource::Index& sub_resource_index = SubResource::Index(), const std::optional<BytesRange>& data_range = {}) = 0;
-    virtual Data::Size                GetDataSize(Data::MemoryState size_type = Data::MemoryState::Reserved) const noexcept = 0;
-    virtual Data::Size                GetSubResourceDataSize(const SubResource::Index& sub_resource_index = SubResource::Index()) const = 0;
-    virtual const SubResource::Count& GetSubresourceCount() const noexcept = 0;
-    virtual Type                      GetResourceType() const noexcept = 0;
-    virtual Usage                     GetUsage() const noexcept = 0;
-    virtual const DescriptorByUsage&  GetDescriptorByUsage() const noexcept = 0;
-    virtual const Descriptor&         GetDescriptor(Usage usage) const = 0;
-    virtual Context&                  GetContext() noexcept = 0;
+    virtual void SetData(const SubResources& sub_resources) = 0;
+    [[nodiscard]] virtual SubResource               GetData(const SubResource::Index& sub_resource_index = SubResource::Index(), const std::optional<BytesRange>& data_range = {}) = 0;
+    [[nodiscard]] virtual Data::Size                GetDataSize(Data::MemoryState size_type = Data::MemoryState::Reserved) const noexcept = 0;
+    [[nodiscard]] virtual Data::Size                GetSubResourceDataSize(const SubResource::Index& sub_resource_index = SubResource::Index()) const = 0;
+    [[nodiscard]] virtual const SubResource::Count& GetSubresourceCount() const noexcept = 0;
+    [[nodiscard]] virtual Type                      GetResourceType() const noexcept = 0;
+    [[nodiscard]] virtual Usage                     GetUsage() const noexcept = 0;
+    [[nodiscard]] virtual const DescriptorByUsage&  GetDescriptorByUsage() const noexcept = 0;
+    [[nodiscard]] virtual const Descriptor&         GetDescriptor(Usage usage) const = 0;
+    [[nodiscard]] virtual Context&                  GetContext() noexcept = 0;
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Sampler.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Sampler.h
@@ -115,10 +115,10 @@ struct Sampler : virtual Resource
     };
 
     // Create Sampler instance
-    static Ptr<Sampler> Create(Context& context, const Settings& state_settings, const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
+    [[nodiscard]] static Ptr<Sampler> Create(Context& context, const Settings& state_settings, const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
 
     // Sampler interface
-    virtual const Settings& GetSettings() const = 0;
+    [[nodiscard]] virtual const Settings& GetSettings() const = 0;
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Shader.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Shader.h
@@ -78,16 +78,16 @@ struct Shader
     };
 
     // Create Shader instance
-    static Ptr<Shader> Create(Type type, Context& context, const Settings& settings);
-    static Ptr<Shader> CreateVertex(Context& context, const Settings& settings) { return Create(Type::Vertex, context, settings); }
-    static Ptr<Shader> CreatePixel(Context& context, const Settings& settings)  { return Create(Type::Pixel, context, settings); }
+    [[nodiscard]] static Ptr<Shader> Create(Type type, Context& context, const Settings& settings);
+    [[nodiscard]] static Ptr<Shader> CreateVertex(Context& context, const Settings& settings) { return Create(Type::Vertex, context, settings); }
+    [[nodiscard]] static Ptr<Shader> CreatePixel(Context& context, const Settings& settings)  { return Create(Type::Pixel, context, settings); }
 
     // Auxiliary functions
-    static std::string ConvertMacroDefinitionsToString(const MacroDefinitions& macro_definitions, const std::string& splitter = ", ") noexcept;
+    [[nodiscard]] static std::string ConvertMacroDefinitionsToString(const MacroDefinitions& macro_definitions, const std::string& splitter = ", ") noexcept;
 
     // Shader interface
-    virtual Type            GetType() const noexcept = 0;
-    virtual const Settings& GetSettings() const noexcept = 0;
+    [[nodiscard]] virtual Type            GetType() const noexcept = 0;
+    [[nodiscard]] virtual const Settings& GetSettings() const noexcept = 0;
 
     virtual ~Shader() = default;
 };

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Shader.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Shader.h
@@ -26,6 +26,7 @@ Methane shader interface: defines programmable stage of the graphics pipeline.
 #include <Methane/Memory.hpp>
 
 #include <string>
+#include <string_view>
 #include <set>
 #include <map>
 
@@ -83,7 +84,7 @@ struct Shader
     [[nodiscard]] static Ptr<Shader> CreatePixel(Context& context, const Settings& settings)  { return Create(Type::Pixel, context, settings); }
 
     // Auxiliary functions
-    [[nodiscard]] static std::string ConvertMacroDefinitionsToString(const MacroDefinitions& macro_definitions, const std::string& splitter = ", ") noexcept;
+    [[nodiscard]] static std::string ConvertMacroDefinitionsToString(const MacroDefinitions& macro_definitions, std::string_view splitter = ", ") noexcept;
 
     // Shader interface
     [[nodiscard]] virtual Type            GetType() const noexcept = 0;

--- a/Modules/Graphics/Core/Include/Methane/Graphics/Texture.h
+++ b/Modules/Graphics/Core/Include/Methane/Graphics/Texture.h
@@ -64,8 +64,8 @@ struct Texture : virtual Resource
 
         using Resource::Location::operator==;
 
-        const Ptr<Texture>& GetTexturePtr() const noexcept { return m_texture_ptr; }
-        Texture&            GetTexture() const;
+        [[nodiscard]] const Ptr<Texture>& GetTexturePtr() const noexcept { return m_texture_ptr; }
+        [[nodiscard]] Texture&            GetTexture() const;
 
     private:
         // Resource::Location stores pointer to the base class Resource, but pointer to Texture is explicitly stored in Texture::Location too
@@ -83,26 +83,26 @@ struct Texture : virtual Resource
         uint32_t       array_length   = 1U;
         bool           mipmapped      = false;
 
-        static Settings Image(const Dimensions& dimensions, uint32_t array_length, PixelFormat pixel_format, bool mipmapped, Usage usage);
-        static Settings Cube(uint32_t dimension_size, uint32_t array_length, PixelFormat pixel_format, bool mipmapped, Usage usage);
-        static Settings FrameBuffer(const Dimensions& dimensions, PixelFormat pixel_format);
-        static Settings DepthStencilBuffer(const Dimensions& dimensions, PixelFormat pixel_format, Usage usage_mask = Usage::RenderTarget);
+        [[nodiscard]] static Settings Image(const Dimensions& dimensions, uint32_t array_length, PixelFormat pixel_format, bool mipmapped, Usage usage);
+        [[nodiscard]] static Settings Cube(uint32_t dimension_size, uint32_t array_length, PixelFormat pixel_format, bool mipmapped, Usage usage);
+        [[nodiscard]] static Settings FrameBuffer(const Dimensions& dimensions, PixelFormat pixel_format);
+        [[nodiscard]] static Settings DepthStencilBuffer(const Dimensions& dimensions, PixelFormat pixel_format, Usage usage_mask = Usage::RenderTarget);
     };
 
     // Create Texture instance
-    static Ptr<Texture> CreateRenderTarget(RenderContext& context, const Settings& settings,
-                                           const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
-    static Ptr<Texture> CreateFrameBuffer(RenderContext& context, uint32_t frame_buffer_index,
-                                          const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
-    static Ptr<Texture> CreateDepthStencilBuffer(RenderContext& context,
+    [[nodiscard]] static Ptr<Texture> CreateRenderTarget(RenderContext& context, const Settings& settings,
+                                                         const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
+    [[nodiscard]] static Ptr<Texture> CreateFrameBuffer(RenderContext& context, uint32_t frame_buffer_index,
+                                                        const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
+    [[nodiscard]] static Ptr<Texture> CreateDepthStencilBuffer(RenderContext& context,
+                                                               const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
+    [[nodiscard]] static Ptr<Texture> CreateImage(Context& context, const Dimensions& dimensions, uint32_t array_length, PixelFormat pixel_format, bool mipmapped,
+                                                  const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
+    [[nodiscard]] static Ptr<Texture> CreateCube(Context& context, uint32_t dimension_size, uint32_t array_length, PixelFormat pixel_format, bool mipmapped,
                                                  const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
-    static Ptr<Texture> CreateImage(Context& context, const Dimensions& dimensions, uint32_t array_length, PixelFormat pixel_format, bool mipmapped,
-                                    const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
-    static Ptr<Texture> CreateCube(Context& context, uint32_t dimension_size, uint32_t array_length, PixelFormat pixel_format, bool mipmapped,
-                                   const DescriptorByUsage& descriptor_by_usage = DescriptorByUsage());
 
     // Texture interface
-    virtual const Settings& GetSettings() const = 0;
+    [[nodiscard]] virtual const Settings& GetSettings() const = 0;
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.cpp
@@ -116,7 +116,7 @@ void CommandListBase::PopDebugGroup()
 void CommandListBase::Reset(DebugGroup* p_debug_group)
 {
     META_FUNCTION_TASK();
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_state_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_state_mutex);
 
     META_CHECK_ARG_DESCR(m_state, m_state != State::Committed && m_state != State::Executing, "can not reset command list in committed or executing state");
     META_LOG("{} Command list '{}' RESET commands encoding", magic_enum::enum_name(m_type), GetName());
@@ -156,7 +156,7 @@ void CommandListBase::SetProgramBindings(ProgramBindings& program_bindings, Prog
 void CommandListBase::Commit()
 {
     META_FUNCTION_TASK();
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_state_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_state_mutex);
 
     META_CHECK_ARG_EQUAL_DESCR(m_state, State::Encoding,
                                "{} command list '{}' in {} state can not be committed; only command lists in 'Encoding' state can be committed",
@@ -198,7 +198,7 @@ void CommandListBase::WaitUntilCompleted(uint32_t timeout_ms)
 void CommandListBase::Execute(uint32_t frame_index, const CompletedCallback& completed_callback)
 {
     META_FUNCTION_TASK();
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_state_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_state_mutex);
 
     META_CHECK_ARG_EQUAL_DESCR(m_state, State::Committed,
                                "{} command list '{}' in {} state can not be executed; only command lists in 'Committed' state can be executed",
@@ -226,7 +226,7 @@ void CommandListBase::Complete(uint32_t frame_index)
 
 void CommandListBase::CompleteInternal(uint32_t frame_index)
 {
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_state_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_state_mutex);
 
     META_CHECK_ARG_EQUAL_DESCR(m_state, State::Executing,
                                "{} command list '{}' in {} state can not be completed; only command lists in 'Executing' state can be completed",
@@ -267,7 +267,7 @@ void CommandListBase::ClearOpenDebugGroups()
 void CommandListBase::SetCommandListState(State state)
 {
     META_FUNCTION_TASK();
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_state_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_state_mutex);
     SetCommandListStateNoLock(state);
 }
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.cpp
@@ -277,7 +277,8 @@ void CommandListBase::SetCommandListStateNoLock(State state)
     if (m_state == state)
         return;
 
-    META_LOG("{} Command list '{}' change state from {} to {}", magic_enum::enum_name(m_type), GetName(), magic_enum::enum_name(m_state), GetStateName(state));
+    META_LOG("{} Command list '{}' change state from {} to {}",
+             magic_enum::enum_name(m_type), GetName(), magic_enum::enum_name(m_state), magic_enum::enum_name(state));
 
     m_state = state;
     m_state_change_condition_var.notify_one();

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.cpp
@@ -139,6 +139,18 @@ void CommandListBase::Reset(DebugGroup* p_debug_group)
     }
 }
 
+void CommandListBase::ResetOnce(DebugGroup* p_debug_group)
+{
+    META_FUNCTION_TASK();
+    if (m_state == State::Encoding)
+    {
+        META_LOG("{} Command list '{}' was already RESET", magic_enum::enum_name(GetType()), GetName());
+        return;
+    }
+
+    Reset(p_debug_group);
+}
+
 void CommandListBase::SetProgramBindings(ProgramBindings& program_bindings, ProgramBindings::ApplyBehavior apply_behavior)
 {
     META_FUNCTION_TASK();

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/CommandListBase.h
@@ -85,6 +85,7 @@ public:
     void  PushDebugGroup(DebugGroup& debug_group) override;
     void  PopDebugGroup() override;
     void  Reset(DebugGroup* p_debug_group = nullptr) override;
+    void  ResetOnce(DebugGroup* p_debug_group = nullptr) final;
     void  SetProgramBindings(ProgramBindings& program_bindings, ProgramBindings::ApplyBehavior apply_behavior) override;
     void  Commit() override;
     void  WaitUntilCompleted(uint32_t timeout_ms = 0U) override;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ContextBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ContextBase.cpp
@@ -164,8 +164,8 @@ void ContextBase::Initialize(DeviceBase& device, bool deferred_heap_allocation, 
     m_device_ptr = device.GetDevicePtr();
     m_upload_fence_ptr = Fence::Create(GetUploadCommandQueue());
 
-    const std::string& context_name = GetName();
-    if (!context_name.empty())
+    if (const std::string& context_name = GetName();
+        !context_name.empty())
     {
         m_device_ptr->SetName(context_name + " Device");
     }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/CoreFormatters.hpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/CoreFormatters.hpp
@@ -31,7 +31,7 @@ Methane Graphics Core objects formatters for use with fmt::format(...)
 template<>
 struct fmt::formatter<Methane::Graphics::Resource::SubResource::Index>
 {
-    constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
+    [[nodiscard]] constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
 
     template<typename FormatContext>
     auto format(const Methane::Graphics::Resource::SubResource::Index& index, FormatContext& ctx)
@@ -43,7 +43,7 @@ struct fmt::formatter<Methane::Graphics::Resource::SubResource::Index>
 template<>
 struct fmt::formatter<Methane::Graphics::Resource::SubResource::Count>
 {
-    constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
+    [[nodiscard]] constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
 
     template<typename FormatContext>
     auto format(const Methane::Graphics::Resource::SubResource::Count& count, FormatContext& ctx)
@@ -55,7 +55,7 @@ struct fmt::formatter<Methane::Graphics::Resource::SubResource::Count>
 template<>
 struct fmt::formatter<Methane::Graphics::Program::Argument>
 {
-    constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
+    [[nodiscard]] constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
 
     template<typename FormatContext>
     auto format(const Methane::Graphics::Program::Argument& program_argument, FormatContext& ctx)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.cpp
@@ -124,8 +124,8 @@ DescriptorHeap::Range DescriptorHeap::ReserveRange(Data::Size length)
     META_CHECK_ARG_NOT_ZERO_DESCR(length, "unable to reserve empty descriptor range");
     std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_modification_mutex);
 
-    Range reserved_range = Data::ReserveRange(m_free_ranges, length);
-    if (reserved_range || !m_settings.deferred_allocation)
+    if (const Range reserved_range = Data::ReserveRange(m_free_ranges, length);
+        reserved_range || !m_settings.deferred_allocation)
         return reserved_range;
 
     Range deferred_range(m_deferred_size, m_deferred_size + length);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.cpp
@@ -59,7 +59,7 @@ DescriptorHeap::~DescriptorHeap()
 {
     META_FUNCTION_TASK();
 
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_modification_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_modification_mutex);
 
     // All descriptor ranges must be released when heap is destroyed
     assert((!m_deferred_size && m_free_ranges.IsEmpty()) ||
@@ -69,7 +69,7 @@ DescriptorHeap::~DescriptorHeap()
 Data::Index DescriptorHeap::AddResource(const ResourceBase& resource)
 {
     META_FUNCTION_TASK();
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_modification_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_modification_mutex);
 
     if (!m_settings.deferred_allocation)
     {
@@ -94,7 +94,7 @@ Data::Index DescriptorHeap::AddResource(const ResourceBase& resource)
 Data::Index DescriptorHeap::ReplaceResource(const ResourceBase& resource, Data::Index at_index)
 {
     META_FUNCTION_TASK();
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_modification_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_modification_mutex);
 
     META_CHECK_ARG_LESS(at_index, m_resources.size());
     m_resources[at_index] = &resource;
@@ -104,7 +104,7 @@ Data::Index DescriptorHeap::ReplaceResource(const ResourceBase& resource, Data::
 void DescriptorHeap::RemoveResource(Data::Index at_index)
 {
     META_FUNCTION_TASK();
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_modification_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_modification_mutex);
 
     META_CHECK_ARG_LESS(at_index, m_resources.size());
     m_resources[at_index] = nullptr;
@@ -122,7 +122,7 @@ DescriptorHeap::Range DescriptorHeap::ReserveRange(Data::Size length)
 {
     META_FUNCTION_TASK();
     META_CHECK_ARG_NOT_ZERO_DESCR(length, "unable to reserve empty descriptor range");
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_modification_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_modification_mutex);
 
     Range reserved_range = Data::ReserveRange(m_free_ranges, length);
     if (reserved_range || !m_settings.deferred_allocation)
@@ -136,7 +136,7 @@ DescriptorHeap::Range DescriptorHeap::ReserveRange(Data::Size length)
 void DescriptorHeap::ReleaseRange(const Range& range)
 {
     META_FUNCTION_TASK();
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_modification_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_modification_mutex);
     m_free_ranges.Add(range);
 }
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DescriptorHeap.h
@@ -85,7 +85,7 @@ public:
 
         Reservation(const Ref<DescriptorHeap>& in_heap, const Range& in_constant_range, const Range& in_mutable_range);
 
-        const Range& GetRange(bool is_constant) const { return is_constant ? constant_range : mutable_range; }
+        [[nodiscard]] const Range& GetRange(bool is_constant) const noexcept { return is_constant ? constant_range : mutable_range; }
     };
 
     static Ptr<DescriptorHeap> Create(ContextBase& context, const Settings& settings);
@@ -102,18 +102,18 @@ public:
 
     void                SetDeferredAllocation(bool deferred_allocation);
 
-    const Settings&     GetSettings() const                             { return m_settings; }
-    Data::Size          GetDeferredSize() const                         { return m_deferred_size; }
-    Data::Size          GetAllocatedSize() const                        { return m_allocated_size; }
-    const ResourceBase* GetResource(uint32_t descriptor_index) const    { return m_resources[descriptor_index]; }
-    bool                IsShaderVisible() const                         { return m_settings.shader_visible && IsShaderVisibleHeapType(m_settings.type); }
+    [[nodiscard]] const Settings&     GetSettings() const                             { return m_settings; }
+    [[nodiscard]] Data::Size          GetDeferredSize() const                         { return m_deferred_size; }
+    [[nodiscard]] Data::Size          GetAllocatedSize() const                        { return m_allocated_size; }
+    [[nodiscard]] const ResourceBase* GetResource(uint32_t descriptor_index) const    { return m_resources[descriptor_index]; }
+    [[nodiscard]] bool                IsShaderVisible() const                         { return m_settings.shader_visible && IsShaderVisibleHeapType(m_settings.type); }
 
-    static bool         IsShaderVisibleHeapType(Type heap_type)         { return heap_type == Type::ShaderResources || heap_type == Type::Samplers; }
+    [[nodiscard]] static bool         IsShaderVisibleHeapType(Type heap_type)         { return heap_type == Type::ShaderResources || heap_type == Type::Samplers; }
 
 protected:
     DescriptorHeap(ContextBase& context, const Settings& settings);
 
-    ContextBase& GetContext() { return m_context; }
+    [[nodiscard]] ContextBase& GetContext() { return m_context; }
 
 private:
     using ResourcePtrs = std::vector<const ResourceBase*>;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/BufferDX.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/BufferDX.h
@@ -166,7 +166,7 @@ public:
         META_CHECK_ARG_NOT_NULL_DESCR(p_sub_resource_data, "failed to map buffer subresource");
 
         stdext::checked_array_iterator<Data::RawPtr> source_data_it(p_sub_resource_data, data_end);
-        Data::Bytes sub_resource_data(data_length, 0);
+        Data::Bytes sub_resource_data(data_length, {});
         std::copy(source_data_it + data_start, source_data_it + data_end, sub_resource_data.begin());
 
         const CD3DX12_RANGE zero_write_range(0, 0);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/CommandListDX.hpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/CommandListDX.hpp
@@ -140,7 +140,7 @@ public:
 
     // CommandList interface
 
-    void Reset(CommandList::DebugGroup* p_debug_group) final
+    void Reset(CommandList::DebugGroup* p_debug_group) override
     {
         META_FUNCTION_TASK();
         if (!m_is_native_committed)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/CommandListDX.hpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/CommandListDX.hpp
@@ -68,8 +68,9 @@ public:
         ThrowIfFailed(cp_device->CreateCommandList(0, command_list_type, m_cp_command_allocator.Get(), nullptr, IID_PPV_ARGS(&m_cp_command_list)), cp_device.Get());
         m_cp_command_list.As(&m_cp_command_list_4);
 
-        TimestampQueryBuffer* p_query_buffer = GetCommandQueueDX().GetTimestampQueryBuffer();
-        if (p_query_buffer)
+
+        if (TimestampQueryBuffer* p_query_buffer = GetCommandQueueDX().GetTimestampQueryBuffer();
+            p_query_buffer)
         {
             m_begin_timestamp_query_ptr = p_query_buffer->CreateTimestampQuery(*this);
             m_end_timestamp_query_ptr   = p_query_buffer->CreateTimestampQuery(*this);
@@ -228,8 +229,19 @@ protected:
         return *m_cp_command_list.Get();
     }
 
-    TimestampQueryBuffer::TimestampQuery* GetBeginTimestampQuery() noexcept { return m_begin_timestamp_query_ptr.get(); }
-    TimestampQueryBuffer::TimestampQuery* GetEndTimestampQuery() noexcept   { return m_end_timestamp_query_ptr.get(); }
+    bool                                  HasBeginTimestampQuery() const noexcept { return !!m_begin_timestamp_query_ptr; }
+    TimestampQueryBuffer::TimestampQuery& GetBeginTimestampQuery() const
+    {
+        META_CHECK_ARG_NOT_NULL(m_begin_timestamp_query_ptr);
+        return *m_begin_timestamp_query_ptr;
+    }
+
+    bool                                  HasEndTimestampQuery() const noexcept   { return !!m_end_timestamp_query_ptr; }
+    TimestampQueryBuffer::TimestampQuery& GetEndTimestampQuery() const
+    {
+        META_CHECK_ARG_NOT_NULL(m_end_timestamp_query_ptr);
+        return m_end_timestamp_query_ptr.get();
+    }
 
 private:
     Ptr<TimestampQueryBuffer::TimestampQuery> m_begin_timestamp_query_ptr;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/CommandQueueDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/CommandQueueDX.cpp
@@ -134,7 +134,7 @@ void CommandQueueDX::Execute(CommandListSet& command_lists, const CommandList::C
     }
 
     auto& dx_command_lists = static_cast<CommandListSetDX&>(command_lists);
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_executing_command_lists_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_executing_command_lists_mutex);
     m_executing_command_lists.push(std::static_pointer_cast<CommandListSetDX>(dx_command_lists.GetPtr()));
     m_execution_waiting_condition_var.notify_one();
 }
@@ -153,7 +153,7 @@ void CommandQueueDX::SetName(const std::string& name)
 void CommandQueueDX::CompleteExecution(const std::optional<Data::Index>& frame_index)
 {
     META_FUNCTION_TASK();
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_executing_command_lists_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_executing_command_lists_mutex);
     while (!m_executing_command_lists.empty() &&
           (!frame_index.has_value() || m_executing_command_lists.front()->GetExecutingOnFrameIndex() == *frame_index))
     {
@@ -216,7 +216,7 @@ void CommandQueueDX::WaitForExecution() noexcept
 const Ptr<CommandListSetDX>& CommandQueueDX::GetNextExecutingCommandListSet() const
 {
     META_FUNCTION_TASK();
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_executing_command_lists_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_executing_command_lists_mutex);
 
     static const Ptr<CommandListSetDX> s_empty_command_list_set_ptr;
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/DescriptorHeapDX.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/DescriptorHeapDX.h
@@ -41,10 +41,10 @@ public:
     DescriptorHeapDX(ContextBase& context, const Settings& settings);
     ~DescriptorHeapDX() override;
 
-    ID3D12DescriptorHeap*       GetNativeDescriptorHeap() noexcept           { return m_cp_descriptor_heap.Get();  }
-    D3D12_DESCRIPTOR_HEAP_TYPE  GetNativeDescriptorHeapType() const noexcept { return m_descriptor_heap_type; }
-    D3D12_CPU_DESCRIPTOR_HANDLE GetNativeCpuDescriptorHandle(uint32_t descriptor_index) const;
-    D3D12_GPU_DESCRIPTOR_HANDLE GetNativeGpuDescriptorHandle(uint32_t descriptor_index) const;
+    [[nodiscard]] ID3D12DescriptorHeap*       GetNativeDescriptorHeap() noexcept           { return m_cp_descriptor_heap.Get();  }
+    [[nodiscard]] D3D12_DESCRIPTOR_HEAP_TYPE  GetNativeDescriptorHeapType() const noexcept { return m_descriptor_heap_type; }
+    [[nodiscard]] D3D12_CPU_DESCRIPTOR_HANDLE GetNativeCpuDescriptorHandle(uint32_t descriptor_index) const;
+    [[nodiscard]] D3D12_GPU_DESCRIPTOR_HANDLE GetNativeGpuDescriptorHandle(uint32_t descriptor_index) const;
 
     // DescriptorHeap interface
     void Allocate() override;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/DeviceDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/DeviceDX.cpp
@@ -101,8 +101,8 @@ const wrl::ComPtr<ID3D12Device>& DeviceDX::GetNativeDevice() const
         m_cp_device->SetName(nowide::widen(GetName()).c_str());
     }
 
-    D3D12_FEATURE_DATA_D3D12_OPTIONS5 feature_options_5{};
-    if (m_cp_device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS5, &feature_options_5, sizeof(feature_options_5)) == S_OK)
+    if (D3D12_FEATURE_DATA_D3D12_OPTIONS5 feature_options_5{};
+        m_cp_device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS5, &feature_options_5, sizeof(feature_options_5)) == S_OK)
     {
         m_feature_options_5 = feature_options_5;
     }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/DeviceDX.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/DeviceDX.h
@@ -68,7 +68,7 @@ private:
 class SystemDX final : public SystemBase
 {
 public:
-    static SystemDX& Get() { return static_cast<SystemDX&>(System::Get()); }
+    [[nodiscard]] static SystemDX& Get() { return static_cast<SystemDX&>(System::Get()); }
 
     SystemDX();
     SystemDX(const SystemDX&) = delete;
@@ -82,7 +82,7 @@ public:
     void  CheckForChanges() override;
     const Ptrs<Device>& UpdateGpuDevices(Device::Features supported_features) override;
 
-    const wrl::ComPtr<IDXGIFactory5>& GetNativeFactory() const noexcept { return m_cp_factory; }
+    [[nodiscard]] const wrl::ComPtr<IDXGIFactory5>& GetNativeFactory() const noexcept { return m_cp_factory; }
     void ReportLiveObjects() const;
 
 private:

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ParallelRenderCommandListDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ParallelRenderCommandListDX.cpp
@@ -32,15 +32,18 @@ DirectX 12 implementation of the parallel render command list interface.
 
 #include <d3dx12.h>
 
+#include <fmt/format.h>
+#include <string_view>
+
 namespace Methane::Graphics
 {
 
-static std::string GetParallelCommandListDebugName(const std::string& base_name, const std::string& suffix)
+static std::string GetParallelCommandListDebugName(std::string_view base_name, std::string_view suffix)
 {
-    return base_name.empty() ? std::string() : base_name + " " + suffix;
+    return base_name.empty() ? std::string() : fmt::format("{} {}", base_name, suffix);
 }
 
-static std::string GetTrailingCommandListDebugName(const std::string& base_name, bool is_beginning)
+static std::string GetTrailingCommandListDebugName(std::string_view base_name, bool is_beginning)
 {
     return GetParallelCommandListDebugName(base_name, is_beginning ? "[Beginning]" : "[Ending]");
 }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ParallelRenderCommandListDX.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ParallelRenderCommandListDX.h
@@ -39,7 +39,7 @@ public:
     ParallelRenderCommandListDX(CommandQueueBase& cmd_buffer, RenderPassBase& render_pass);
 
     // ParallelRenderCommandList interface
-    void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) override;
+    void ResetWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) override;
 
     // CommandList interface
     void Commit() override;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ProgramBindingsDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ProgramBindingsDX.cpp
@@ -253,21 +253,23 @@ void ProgramBindingsDX::ForEachArgumentBinding(FuncType argument_binding_functio
     for (auto& [program_argument, argument_binding_ptr] : GetArgumentBindings())
     {
         META_CHECK_ARG_NOT_NULL(argument_binding_ptr);
-
         auto& argument_binding = static_cast<ArgumentBindingDX&>(*argument_binding_ptr);
-        const ArgumentBindingDX::DescriptorRange& descriptor_range   = argument_binding.GetDescriptorRange();
-        const DescriptorHeap::Reservation*        p_heap_reservation = nullptr;
+        const ArgumentBindingDX::DescriptorRange& descriptor_range = argument_binding.GetDescriptorRange();
 
-        if (descriptor_range.heap_type != DescriptorHeap::Type::Undefined)
+        if (descriptor_range.heap_type == DescriptorHeap::Type::Undefined)
         {
-            const std::optional<DescriptorHeap::Reservation>& descriptor_heap_reservation_opt = GetDescriptorHeapReservationByType(descriptor_range.heap_type);
-            if (descriptor_heap_reservation_opt)
-            {
-                p_heap_reservation = &*descriptor_heap_reservation_opt;
-            }
+            argument_binding_function(argument_binding, nullptr);
+            continue;
         }
 
-        argument_binding_function(argument_binding, p_heap_reservation);
+        if (const std::optional<DescriptorHeap::Reservation>& desc_heap_reservation_opt = GetDescriptorHeapReservationByType(descriptor_range.heap_type);
+            desc_heap_reservation_opt.has_value())
+        {
+            argument_binding_function(argument_binding, &*desc_heap_reservation_opt);
+            continue;
+        }
+
+        argument_binding_function(argument_binding, nullptr);
     }
 }
 
@@ -387,9 +389,8 @@ bool ProgramBindingsDX::ApplyResourceStates(bool apply_constant_resource_states)
 void ProgramBindingsDX::ApplyRootParameterBinding(const RootParameterBinding& root_parameter_binding, ID3D12GraphicsCommandList& d3d12_command_list) const
 {
     META_FUNCTION_TASK();
-    const ArgumentBindingDX::Type binding_type = root_parameter_binding.argument_binding.GetSettingsDX().type;
-
-    switch (binding_type)
+    switch (const ArgumentBindingDX::Type binding_type = root_parameter_binding.argument_binding.GetSettingsDX().type;
+            binding_type)
     {
     case ArgumentBindingDX::Type::DescriptorTable:
         d3d12_command_list.SetGraphicsRootDescriptorTable(root_parameter_binding.root_parameter_index, root_parameter_binding.base_descriptor);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ProgramBindingsDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ProgramBindingsDX.cpp
@@ -250,11 +250,11 @@ template<typename FuncType>
 void ProgramBindingsDX::ForEachArgumentBinding(FuncType argument_binding_function) const
 {
     META_FUNCTION_TASK();
-    for (auto& binding_by_argument : GetArgumentBindings())
+    for (auto& [program_argument, argument_binding_ptr] : GetArgumentBindings())
     {
-        META_CHECK_ARG_NOT_NULL(binding_by_argument.second);
+        META_CHECK_ARG_NOT_NULL(argument_binding_ptr);
 
-        auto& argument_binding = static_cast<ArgumentBindingDX&>(*binding_by_argument.second);
+        auto& argument_binding = static_cast<ArgumentBindingDX&>(*argument_binding_ptr);
         const ArgumentBindingDX::DescriptorRange& descriptor_range   = argument_binding.GetDescriptorRange();
         const DescriptorHeap::Reservation*        p_heap_reservation = nullptr;
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ProgramDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ProgramDX.cpp
@@ -46,6 +46,7 @@ struct DescriptorOffsets
     uint32_t mutable_offset = 0;
 };
 
+[[nodiscard]]
 static D3D12_DESCRIPTOR_RANGE_TYPE GetDescriptorRangeTypeByShaderInputType(D3D_SHADER_INPUT_TYPE input_type)
 {
     META_FUNCTION_TASK();
@@ -76,6 +77,7 @@ static D3D12_DESCRIPTOR_RANGE_TYPE GetDescriptorRangeTypeByShaderInputType(D3D_S
     }
 }
 
+[[nodiscard]]
 static DescriptorHeap::Type GetDescriptorHeapTypeByRangeType(D3D12_DESCRIPTOR_RANGE_TYPE range_type) noexcept
 {
     META_FUNCTION_TASK();
@@ -85,6 +87,7 @@ static DescriptorHeap::Type GetDescriptorHeapTypeByRangeType(D3D12_DESCRIPTOR_RA
         return DescriptorHeap::Type::ShaderResources;
 }
 
+[[nodiscard]]
 static D3D12_SHADER_VISIBILITY GetShaderVisibilityByType(Shader::Type shader_type)
 {
     META_FUNCTION_TASK();

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ProgramDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ProgramDX.cpp
@@ -161,14 +161,13 @@ void ProgramDX::InitRootSignature()
     root_parameters.reserve(binding_by_argument.size());
 
     std::map<DescriptorHeap::Type, DescriptorOffsets> descriptor_offset_by_heap_type;
-    for (auto& argument_and_binding : binding_by_argument)
+    for (const auto& [program_argument, argument_binding_ptr] : binding_by_argument)
     {
-        META_CHECK_ARG_NOT_NULL(argument_and_binding.second);
+        META_CHECK_ARG_NOT_NULL(argument_binding_ptr);
 
-        const Argument&                    shader_argument = argument_and_binding.first;
-        auto&                             argument_binding = static_cast<ArgumentBindingDX&>(*argument_and_binding.second);
+        auto&                             argument_binding = static_cast<ArgumentBindingDX&>(*argument_binding_ptr);
         const ArgumentBindingDX::SettingsDX& bind_settings = argument_binding.GetSettingsDX();
-        const D3D12_SHADER_VISIBILITY    shader_visibility = GetShaderVisibilityByType(shader_argument.shader_type);
+        const D3D12_SHADER_VISIBILITY    shader_visibility = GetShaderVisibilityByType(program_argument.shader_type);
 
         argument_binding.SetRootParameterIndex(static_cast<uint32_t>(root_parameters.size()));
         root_parameters.emplace_back();

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/QueryBufferDX.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/QueryBufferDX.h
@@ -52,7 +52,7 @@ public:
         Resource::SubResource GetData() override;
 
     protected:
-        QueryBufferDX& GetQueryBufferDX() noexcept  { return static_cast<QueryBufferDX&>(GetQueryBuffer()); }
+        [[nodiscard]] QueryBufferDX& GetQueryBufferDX() noexcept  { return static_cast<QueryBufferDX&>(GetQueryBuffer()); }
 
     private:
         ID3D12GraphicsCommandList&  m_native_command_list;
@@ -100,7 +100,7 @@ public:
         Timestamp GetCpuNanoseconds() override;
 
     private:
-        TimestampQueryBufferDX& GetTimestampQueryBufferDX() noexcept { return static_cast<TimestampQueryBufferDX&>(GetQueryBuffer()); }
+        [[nodiscard]] TimestampQueryBufferDX& GetTimestampQueryBufferDX() noexcept { return static_cast<TimestampQueryBufferDX&>(GetQueryBuffer()); }
     };
 
     TimestampQueryBufferDX(CommandQueueDX& command_queue, uint32_t max_timestamps_per_frame);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderCommandListDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderCommandListDX.cpp
@@ -78,7 +78,7 @@ RenderCommandListDX::RenderCommandListDX(ParallelRenderCommandListBase& parallel
     META_FUNCTION_TASK();
 }
 
-void RenderCommandListDX::ResetNative(const Ptr<RenderState>& render_state_ptr)
+void RenderCommandListDX::ResetNative(const Ptr<RenderStateDX>& render_state_ptr)
 {
     META_FUNCTION_TASK();
     if (!IsNativeCommitted())
@@ -87,7 +87,7 @@ void RenderCommandListDX::ResetNative(const Ptr<RenderState>& render_state_ptr)
     SetNativeCommitted(false);
     SetCommandListState(CommandList::State::Encoding);
 
-    ID3D12PipelineState* p_dx_initial_state = render_state_ptr ? static_cast<RenderStateDX&>(*render_state_ptr).GetNativePipelineState().Get() : nullptr;
+    ID3D12PipelineState* p_dx_initial_state = render_state_ptr ? render_state_ptr->GetNativePipelineState().Get() : nullptr;
     ID3D12CommandAllocator& dx_cmd_allocator = GetNativeCommandAllocatorRef();
     ID3D12Device* p_native_device = GetCommandQueueDX().GetContextDX().GetDeviceDX().GetNativeDevice().Get();
     ThrowIfFailed(dx_cmd_allocator.Reset(), p_native_device);
@@ -102,21 +102,17 @@ void RenderCommandListDX::ResetNative(const Ptr<RenderState>& render_state_ptr)
 
     using namespace magic_enum::bitwise_operators;
     DrawingState& drawing_state = GetDrawingState();
-    drawing_state.render_state_ptr    = std::static_pointer_cast<RenderStateBase>(render_state_ptr);
+    drawing_state.render_state_ptr    = render_state_ptr;
     drawing_state.render_state_groups = RenderState::Groups::Program
                                       | RenderState::Groups::Rasterizer
                                       | RenderState::Groups::DepthStencil;
 }
 
-void RenderCommandListDX::ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group)
+void RenderCommandListDX::ResetRenderPass()
 {
     META_FUNCTION_TASK();
-
-    ResetNative(render_state_ptr);
-
-    RenderCommandListBase::ResetWithState(render_state_ptr, p_debug_group);
-
     RenderPassDX& pass_dx = GetPassDX();
+
     if (IsParallel())
     {
         pass_dx.SetNativeDescriptorHeaps(*this);
@@ -126,6 +122,22 @@ void RenderCommandListDX::ResetWithState(const Ptr<RenderState>& render_state_pt
     {
         pass_dx.Begin(*this);
     }
+}
+
+void RenderCommandListDX::Reset(DebugGroup* p_debug_group)
+{
+    META_FUNCTION_TASK();
+    ResetNative();
+    RenderCommandListBase::Reset(p_debug_group);
+    ResetRenderPass();
+}
+
+void RenderCommandListDX::ResetWithState(RenderState& render_state, DebugGroup* p_debug_group)
+{
+    META_FUNCTION_TASK();
+    ResetNative(std::static_pointer_cast<RenderStateDX>(static_cast<RenderStateBase&>(render_state).GetBasePtr()));
+    RenderCommandListBase::ResetWithState(render_state, p_debug_group);
+    ResetRenderPass();
 }
 
 void RenderCommandListDX::SetVertexBuffers(BufferSet& vertex_buffers)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderCommandListDX.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderCommandListDX.h
@@ -31,6 +31,7 @@ namespace Methane::Graphics
 {
 
 class RenderPassDX;
+class RenderStateDX;
 
 class RenderCommandListDX final : public CommandListDX<RenderCommandListBase>
 {
@@ -42,7 +43,8 @@ public:
     void Commit() override;
 
     // RenderCommandList interface
-    void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) override;
+    void Reset(DebugGroup* p_debug_group = nullptr) override;
+    void ResetWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) override;
     void SetVertexBuffers(BufferSet& vertex_buffers) override;
     void DrawIndexed(Primitive primitive, Buffer& index_buffer,
                      uint32_t index_count, uint32_t start_index, uint32_t start_vertex, 
@@ -50,9 +52,11 @@ public:
     void Draw(Primitive primitive, uint32_t vertex_count, uint32_t start_vertex,
               uint32_t instance_count, uint32_t start_instance) override;
 
-    void ResetNative(const Ptr<RenderState>& render_state_ptr = Ptr<RenderState>());
+    void ResetNative(const Ptr<RenderStateDX>& render_state_ptr = nullptr);
 
 private:
+    void ResetRenderPass();
+
     RenderPassDX& GetPassDX();
 };
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderStateDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderStateDX.cpp
@@ -93,13 +93,13 @@ static UINT8 ConvertRenderTargetWriteMaskToD3D12(RenderState::Blending::ColorCha
 
     UINT8 d3d12_color_write_mask = 0;
     if (magic_enum::flags::enum_contains(rt_write_mask & ColorChannels::Red))
-        d3d12_color_write_mask |= D3D12_COLOR_WRITE_ENABLE_RED;
+        d3d12_color_write_mask |= D3D12_COLOR_WRITE_ENABLE_RED;   // NOSONAR
     if (magic_enum::flags::enum_contains(rt_write_mask & ColorChannels::Green))
-        d3d12_color_write_mask |= D3D12_COLOR_WRITE_ENABLE_GREEN;
+        d3d12_color_write_mask |= D3D12_COLOR_WRITE_ENABLE_GREEN; // NOSONAR
     if (magic_enum::flags::enum_contains(rt_write_mask & ColorChannels::Blue))
-        d3d12_color_write_mask |= D3D12_COLOR_WRITE_ENABLE_BLUE;
+        d3d12_color_write_mask |= D3D12_COLOR_WRITE_ENABLE_BLUE;  // NOSONAR
     if (magic_enum::flags::enum_contains(rt_write_mask & ColorChannels::Alpha))
-        d3d12_color_write_mask |= D3D12_COLOR_WRITE_ENABLE_ALPHA;
+        d3d12_color_write_mask |= D3D12_COLOR_WRITE_ENABLE_ALPHA; // NOSONAR
     return d3d12_color_write_mask;
 };
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderStateDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/RenderStateDX.cpp
@@ -45,6 +45,7 @@ namespace Methane::Graphics
 
 constexpr size_t g_max_rtv_count = sizeof(D3D12_GRAPHICS_PIPELINE_STATE_DESC::RTVFormats) / sizeof(DXGI_FORMAT);
 
+[[nodiscard]]
 inline CD3DX12_SHADER_BYTECODE GetShaderByteCode(const Ptr<Shader>& shader_ptr)
 {
     META_FUNCTION_TASK();
@@ -54,6 +55,7 @@ inline CD3DX12_SHADER_BYTECODE GetShaderByteCode(const Ptr<Shader>& shader_ptr)
         : CD3DX12_SHADER_BYTECODE(nullptr, 0);
 }
 
+[[nodiscard]]
 static D3D12_FILL_MODE ConvertRasterizerFillModeToD3D12(RenderState::Rasterizer::FillMode fill_mode)
 {
     META_FUNCTION_TASK();
@@ -67,6 +69,7 @@ static D3D12_FILL_MODE ConvertRasterizerFillModeToD3D12(RenderState::Rasterizer:
     }
 }
 
+[[nodiscard]]
 static D3D12_CULL_MODE ConvertRasterizerCullModeToD3D12(RenderState::Rasterizer::CullMode cull_mode)
 {
     META_FUNCTION_TASK();
@@ -81,6 +84,7 @@ static D3D12_CULL_MODE ConvertRasterizerCullModeToD3D12(RenderState::Rasterizer:
     }
 }
 
+[[nodiscard]]
 static UINT8 ConvertRenderTargetWriteMaskToD3D12(RenderState::Blending::ColorChannels rt_write_mask)
 {
     META_FUNCTION_TASK();
@@ -99,6 +103,7 @@ static UINT8 ConvertRenderTargetWriteMaskToD3D12(RenderState::Blending::ColorCha
     return d3d12_color_write_mask;
 };
 
+[[nodiscard]]
 static D3D12_BLEND_OP ConvertBlendingOperationToD3D12(RenderState::Blending::Operation blend_operation)
 {
     META_FUNCTION_TASK();
@@ -115,6 +120,7 @@ static D3D12_BLEND_OP ConvertBlendingOperationToD3D12(RenderState::Blending::Ope
     }
 }
 
+[[nodiscard]]
 static D3D12_BLEND ConvertBlendingFactorToD3D12(RenderState::Blending::Factor blend_factor)
 {
     META_FUNCTION_TASK();
@@ -145,6 +151,7 @@ static D3D12_BLEND ConvertBlendingFactorToD3D12(RenderState::Blending::Factor bl
     }
 }
 
+[[nodiscard]]
 static D3D12_STENCIL_OP ConvertStencilOperationToD3D12(RenderState::Stencil::Operation operation)
 {
     META_FUNCTION_TASK();
@@ -164,6 +171,7 @@ static D3D12_STENCIL_OP ConvertStencilOperationToD3D12(RenderState::Stencil::Ope
     }
 }
 
+[[nodiscard]]
 static D3D12_DEPTH_STENCILOP_DESC ConvertStencilFaceOperationsToD3D12(const RenderState::Stencil::FaceOperations& stencil_face_op)
 {
     META_FUNCTION_TASK();
@@ -177,6 +185,7 @@ static D3D12_DEPTH_STENCILOP_DESC ConvertStencilFaceOperationsToD3D12(const Rend
     return stencil_desc;
 }
 
+[[nodiscard]]
 static CD3DX12_VIEWPORT ViewportToD3D(const Viewport& viewport) noexcept
 {
     META_FUNCTION_TASK();
@@ -185,6 +194,7 @@ static CD3DX12_VIEWPORT ViewportToD3D(const Viewport& viewport) noexcept
                             static_cast<float>(viewport.origin.GetZ()), static_cast<float>(viewport.origin.GetZ() + viewport.size.depth));
 }
 
+[[nodiscard]]
 static CD3DX12_RECT ScissorRectToD3D(const ScissorRect& scissor_rect) noexcept
 {
     META_FUNCTION_TASK();
@@ -193,6 +203,7 @@ static CD3DX12_RECT ScissorRectToD3D(const ScissorRect& scissor_rect) noexcept
                         static_cast<LONG>(scissor_rect.origin.GetY() + scissor_rect.size.height));
 }
 
+[[nodiscard]]
 static std::vector<CD3DX12_VIEWPORT> ViewportsToD3D(const Viewports& viewports) noexcept
 {
     META_FUNCTION_TASK();
@@ -205,6 +216,7 @@ static std::vector<CD3DX12_VIEWPORT> ViewportsToD3D(const Viewports& viewports) 
     return d3d_viewports;
 }
 
+[[nodiscard]]
 static std::vector<CD3DX12_RECT> ScissorRectsToD3D(const ScissorRects& scissor_rects) noexcept
 {
     META_FUNCTION_TASK();

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ResourceDX.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ResourceDX.h
@@ -47,7 +47,7 @@ public:
 
         bool AddStateChange(const Barrier::Id& id, const Barrier::StateChange& state_change) override;
 
-        const std::vector<D3D12_RESOURCE_BARRIER>& GetNativeResourceBarriers() const { return m_native_resource_barriers; }
+        [[nodiscard]] const std::vector<D3D12_RESOURCE_BARRIER>& GetNativeResourceBarriers() const { return m_native_resource_barriers; }
 
     private:
         std::vector<D3D12_RESOURCE_BARRIER> m_native_resource_barriers;
@@ -59,8 +59,8 @@ public:
         explicit LocationDX(const Location& location);
         ~LocationDX() = default;
 
-        IResourceDX&              GetResourceDX() const noexcept       { return m_resource_dx.get(); }
-        D3D12_GPU_VIRTUAL_ADDRESS GetNativeGpuAddress() const noexcept { return GetResourceDX().GetNativeGpuAddress() + GetOffset(); }
+        [[nodiscard]] IResourceDX&              GetResourceDX() const noexcept       { return m_resource_dx.get(); }
+        [[nodiscard]] D3D12_GPU_VIRTUAL_ADDRESS GetNativeGpuAddress() const noexcept { return GetResourceDX().GetNativeGpuAddress() + GetOffset(); }
 
     private:
         Ref<IResourceDX> m_resource_dx;
@@ -68,19 +68,19 @@ public:
 
     using LocationsDX = std::vector<LocationDX>;
 
-    static D3D12_RESOURCE_STATES  GetNativeResourceState(State resource_state);
-    static D3D12_RESOURCE_BARRIER GetNativeResourceBarrier(const Barrier& resource_barrier)  { return GetNativeResourceBarrier(resource_barrier.GetId(), resource_barrier.GetStateChange()); }
-    static D3D12_RESOURCE_BARRIER GetNativeResourceBarrier(const Barrier::Id& id, const Barrier::StateChange& state_change);
+    [[nodiscard]] static D3D12_RESOURCE_STATES  GetNativeResourceState(State resource_state);
+    [[nodiscard]] static D3D12_RESOURCE_BARRIER GetNativeResourceBarrier(const Barrier& resource_barrier)  { return GetNativeResourceBarrier(resource_barrier.GetId(), resource_barrier.GetStateChange()); }
+    [[nodiscard]] static D3D12_RESOURCE_BARRIER GetNativeResourceBarrier(const Barrier::Id& id, const Barrier::StateChange& state_change);
 
-    virtual ID3D12Resource&                     GetNativeResourceRef() const = 0;
-    virtual ID3D12Resource*                     GetNativeResource() const noexcept = 0;
-    virtual const wrl::ComPtr<ID3D12Resource>&  GetNativeResourceComPtr() const noexcept = 0;
-    virtual D3D12_GPU_VIRTUAL_ADDRESS           GetNativeGpuAddress() const noexcept = 0;
-    virtual D3D12_CPU_DESCRIPTOR_HANDLE         GetNativeCpuDescriptorHandle(Usage usage) const noexcept = 0;
-    virtual D3D12_CPU_DESCRIPTOR_HANDLE         GetNativeCpuDescriptorHandle(const Descriptor& desc) const noexcept = 0;
-    virtual D3D12_GPU_DESCRIPTOR_HANDLE         GetNativeGpuDescriptorHandle(Usage usage) const noexcept = 0;
-    virtual D3D12_GPU_DESCRIPTOR_HANDLE         GetNativeGpuDescriptorHandle(const Descriptor& desc) const noexcept = 0;
-    virtual DescriptorHeap::Types               GetDescriptorHeapTypes() const noexcept = 0;
+    [[nodiscard]] virtual ID3D12Resource&                     GetNativeResourceRef() const = 0;
+    [[nodiscard]] virtual ID3D12Resource*                     GetNativeResource() const noexcept = 0;
+    [[nodiscard]] virtual const wrl::ComPtr<ID3D12Resource>&  GetNativeResourceComPtr() const noexcept = 0;
+    [[nodiscard]] virtual D3D12_GPU_VIRTUAL_ADDRESS           GetNativeGpuAddress() const noexcept = 0;
+    [[nodiscard]] virtual D3D12_CPU_DESCRIPTOR_HANDLE         GetNativeCpuDescriptorHandle(Usage usage) const noexcept = 0;
+    [[nodiscard]] virtual D3D12_CPU_DESCRIPTOR_HANDLE         GetNativeCpuDescriptorHandle(const Descriptor& desc) const noexcept = 0;
+    [[nodiscard]] virtual D3D12_GPU_DESCRIPTOR_HANDLE         GetNativeGpuDescriptorHandle(Usage usage) const noexcept = 0;
+    [[nodiscard]] virtual D3D12_GPU_DESCRIPTOR_HANDLE         GetNativeGpuDescriptorHandle(const Descriptor& desc) const noexcept = 0;
+    [[nodiscard]] virtual DescriptorHeap::Types               GetDescriptorHeapTypes() const noexcept = 0;
 
     ~IResourceDX() override = default;
 };

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ShaderDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/ShaderDX.cpp
@@ -43,6 +43,7 @@ DirectX 12 implementation of the shader interface.
 namespace Methane::Graphics
 {
 
+[[nodiscard]]
 static Resource::Type GetResourceTypeByInputType(D3D_SHADER_INPUT_TYPE input_type)
 {
     META_FUNCTION_TASK();
@@ -56,6 +57,7 @@ static Resource::Type GetResourceTypeByInputType(D3D_SHADER_INPUT_TYPE input_typ
     }
 }
 
+[[nodiscard]]
 static std::string GetShaderInputTypeName(D3D_SHADER_INPUT_TYPE input_type)
 {
     META_FUNCTION_TASK();
@@ -77,6 +79,7 @@ static std::string GetShaderInputTypeName(D3D_SHADER_INPUT_TYPE input_type)
     }
 }
 
+[[nodiscard]]
 static std::string GetSRVDimensionName(D3D_SRV_DIMENSION srv_dimension)
 {
     META_FUNCTION_TASK();
@@ -98,6 +101,7 @@ static std::string GetSRVDimensionName(D3D_SRV_DIMENSION srv_dimension)
     }
 }
 
+[[nodiscard]]
 static std::string GetReturnTypeName(D3D_RESOURCE_RETURN_TYPE return_type)
 {
     META_FUNCTION_TASK();

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/TextureDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/TextureDX.cpp
@@ -175,9 +175,8 @@ DepthStencilBufferTextureDX::TextureDX(ContextBase& render_context, const Settin
             continue;
 
         const Descriptor& desc = ResourceBase::GetDescriptorByUsage(usage);
-        const DescriptorHeap::Type descriptor_heap_type = desc.heap.GetSettings().type;
-
-        switch (descriptor_heap_type)
+        switch (const DescriptorHeap::Type descriptor_heap_type = desc.heap.GetSettings().type;
+                descriptor_heap_type)
         {
         case DescriptorHeap::Type::ShaderResources: CreateShaderResourceView(settings, cp_device, desc); break;
         case DescriptorHeap::Type::DepthStencil:    CreateDepthStencilView(settings, view_write_format, cp_device, desc); break;
@@ -418,8 +417,7 @@ void ImageTextureDX::GenerateMipLevels(std::vector<D3D12_SUBRESOURCE_DATA>& dx_s
     for(uint32_t sub_resource_raw_index = 0; sub_resource_raw_index < dx_sub_resources.size(); ++sub_resource_raw_index)
     {
         // Initialize images of base mip-levels only
-        const SubResource::Index sub_resource_index(sub_resource_raw_index, sub_resource_count);
-        if (sub_resource_index.GetMipLevel() > 0)
+        if (SubResource::Index(sub_resource_raw_index, sub_resource_count).GetMipLevel() > 0)
             continue;
 
         const D3D12_SUBRESOURCE_DATA& dx_sub_resource = dx_sub_resources[sub_resource_raw_index];

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/TextureDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/TextureDX.cpp
@@ -222,14 +222,14 @@ ImageTextureDX::TextureDX(ContextBase& render_context, const Settings& settings,
 
     InitializeDefaultDescriptors();
 
-    const ResourceAndViewDesc tex_and_srv_desc = GetResourceAndViewDesc();
-    InitializeCommittedResource(tex_and_srv_desc.first, D3D12_HEAP_TYPE_DEFAULT, D3D12_RESOURCE_STATE_COPY_DEST);
+    const auto [resource_desc, srv_desc] = GetResourceAndViewDesc();
+    InitializeCommittedResource(resource_desc, D3D12_HEAP_TYPE_DEFAULT, D3D12_RESOURCE_STATE_COPY_DEST);
 
     const UINT64 upload_buffer_size = GetRequiredIntermediateSize(GetNativeResource(), 0, GetSubresourceCount().GetRawCount());
     m_cp_upload_resource = CreateCommittedResource(CD3DX12_RESOURCE_DESC::Buffer(upload_buffer_size), D3D12_HEAP_TYPE_UPLOAD, D3D12_RESOURCE_STATE_GENERIC_READ);
 
     const wrl::ComPtr<ID3D12Device>& cp_device = GetContextDX().GetDeviceDX().GetNativeDevice();
-    cp_device->CreateShaderResourceView(GetNativeResource(), &tex_and_srv_desc.second, GetNativeCpuDescriptorHandle(Usage::ShaderRead));
+    cp_device->CreateShaderResourceView(GetNativeResource(), &srv_desc, GetNativeCpuDescriptorHandle(Usage::ShaderRead));
 }
 
 void ImageTextureDX::SetName(const std::string& name)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/TextureDX.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/DirectX12/TextureDX.cpp
@@ -40,6 +40,7 @@ DirectX 12 implementation of the texture interface.
 namespace Methane::Graphics
 {
 
+[[nodiscard]]
 static D3D12_SRV_DIMENSION GetSrvDimension(const Dimensions& tex_dimensions) noexcept
 {
     META_FUNCTION_TASK();
@@ -47,6 +48,7 @@ static D3D12_SRV_DIMENSION GetSrvDimension(const Dimensions& tex_dimensions) noe
     return tex_dimensions.depth == 1 ? flat_dimension : D3D12_SRV_DIMENSION_TEXTURE3D;
 }
 
+[[nodiscard]]
 static D3D12_DSV_DIMENSION GetDsvDimension(const Dimensions& tex_dimensions)
 {
     META_FUNCTION_TASK();

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/CommandListMT.hpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/CommandListMT.hpp
@@ -60,7 +60,7 @@ public:
     void PushDebugGroup(CommandList::DebugGroup& debug_group) override
     {
         META_FUNCTION_TASK();
-        std::lock_guard<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
+        std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
 
         CommandListBaseT::PushDebugGroup(debug_group);
 
@@ -71,7 +71,7 @@ public:
     void PopDebugGroup() override
     {
         META_FUNCTION_TASK();
-        std::lock_guard<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
+        std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
 
         CommandListBaseT::PopDebugGroup();
 
@@ -86,7 +86,7 @@ public:
 
         CommandListBaseT::Commit();
 
-        std::lock_guard<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
+        std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
 
         if (m_mtl_cmd_encoder)
         {
@@ -131,7 +131,7 @@ public:
     void Execute(uint32_t frame_index, const CommandList::CompletedCallback& completed_callback) override
     {
         META_FUNCTION_TASK();
-        std::lock_guard<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
+        std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
 
         CommandListBaseT::Execute(frame_index, completed_callback);
 
@@ -139,7 +139,7 @@ public:
             return;
 
         [m_mtl_cmd_buffer addCompletedHandler:^(id<MTLCommandBuffer>) {
-            std::lock_guard<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
+            std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
             CommandListBaseT::Complete(frame_index);
             [m_mtl_cmd_buffer release];
             m_mtl_cmd_buffer  = nil;
@@ -153,7 +153,7 @@ public:
     void SetName(const std::string& name) override
     {
         META_FUNCTION_TASK();
-        std::lock_guard<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
+        std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
 
         CommandListBaseT::SetName(name);
         m_ns_name = MacOS::ConvertToNsType<std::string, NSString*>(name);
@@ -181,7 +181,7 @@ protected:
     id<MTLCommandBuffer>& InitializeCommandBuffer()
     {
         META_FUNCTION_TASK();
-        std::lock_guard<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
+        std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_cmd_buffer_mutex);
 
         if (m_mtl_cmd_buffer)
             return m_mtl_cmd_buffer;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ContextMT.hpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ContextMT.hpp
@@ -76,7 +76,7 @@ public:
         if (library_by_name_it != m_library_by_name.end())
             return library_by_name_it->second;
 
-        return m_library_by_name.emplace(library_name, std::make_shared<ProgramLibraryMT>(GetDeviceMT(), library_name)).first->second;
+        return m_library_by_name.try_emplace(library_name, std::make_shared<ProgramLibraryMT>(GetDeviceMT(), library_name)).first->second;
     }
 
     // Object overrides

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ParallelRenderCommandListMT.hh
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ParallelRenderCommandListMT.hh
@@ -43,10 +43,12 @@ public:
     ParallelRenderCommandListMT(CommandQueueBase& command_queue, RenderPassBase& render_pass);
 
     // ParallelRenderCommandList interface
-    void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) override;
+    void Reset(DebugGroup* p_debug_group = nullptr) override;
+    void ResetWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) override;
 
 private:
     RenderPassMT& GetRenderPassMT();
+    bool ResetCommandEncoder();
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ParallelRenderCommandListMT.mm
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ParallelRenderCommandListMT.mm
@@ -43,14 +43,28 @@ ParallelRenderCommandListMT::ParallelRenderCommandListMT(CommandQueueBase& comma
     META_FUNCTION_TASK();
 }
 
-void ParallelRenderCommandListMT::ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group)
+void ParallelRenderCommandListMT::Reset(DebugGroup* p_debug_group)
+{
+    META_FUNCTION_TASK();
+    ResetCommandEncoder();
+    ParallelRenderCommandListBase::Reset(p_debug_group);
+}
+
+void ParallelRenderCommandListMT::ResetWithState(RenderState& render_state, DebugGroup* p_debug_group)
+{
+    META_FUNCTION_TASK();
+    if (ResetCommandEncoder())
+    {
+        static_cast<RenderStateMT&>(render_state.InitializeNativeStates();
+    }
+    ParallelRenderCommandListBase::ResetWithState(render_state, p_debug_group);
+}
+
+bool ParallelRenderCommandListMT::ResetCommandEncoder()
 {
     META_FUNCTION_TASK();
     if (IsCommandEncoderInitialized())
-    {
-        ParallelRenderCommandListBase::ResetWithState(render_state_ptr, p_debug_group);
-        return;
-    }
+        return false;
 
     // NOTE: If command buffer was not created for current frame yet,
     // then render pass descriptor should be reset with new frame drawable
@@ -59,13 +73,7 @@ void ParallelRenderCommandListMT::ResetWithState(const Ptr<RenderState>& render_
 
     id<MTLCommandBuffer>& mtl_cmd_buffer = InitializeCommandBuffer();
     InitializeCommandEncoder([mtl_cmd_buffer parallelRenderCommandEncoderWithDescriptor: mtl_render_pass]);
-    
-    if (render_state_ptr)
-    {
-        static_cast<RenderStateMT&>(*render_state_ptr).InitializeNativeStates();
-    }
-
-    ParallelRenderCommandListBase::ResetWithState(render_state_ptr, p_debug_group);
+    return true;
 }
 
 RenderPassMT& ParallelRenderCommandListMT::GetRenderPassMT()

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ParallelRenderCommandListMT.mm
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/ParallelRenderCommandListMT.mm
@@ -55,7 +55,7 @@ void ParallelRenderCommandListMT::ResetWithState(RenderState& render_state, Debu
     META_FUNCTION_TASK();
     if (ResetCommandEncoder())
     {
-        static_cast<RenderStateMT&>(render_state.InitializeNativeStates();
+        static_cast<RenderStateMT&>(render_state).InitializeNativeStates();
     }
     ParallelRenderCommandListBase::ResetWithState(render_state, p_debug_group);
 }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/RenderCommandListMT.hh
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/RenderCommandListMT.hh
@@ -44,7 +44,8 @@ public:
     explicit RenderCommandListMT(ParallelRenderCommandListBase& parallel_render_command_list);
 
     // RenderCommandList interface
-    void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) override;
+    void Reset(DebugGroup* p_debug_group = nullptr) override;
+    void ResetWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) override;
     void SetVertexBuffers(BufferSet& vertex_buffers) override;
     void DrawIndexed(Primitive primitive, Buffer& index_buffer,
                      uint32_t index_count, uint32_t start_index, uint32_t start_vertex,
@@ -54,6 +55,7 @@ public:
 
 private:
     RenderPassMT& GetRenderPassMT();
+    void ResetCommandEncoder();
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/RenderCommandListMT.mm
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Metal/RenderCommandListMT.mm
@@ -75,14 +75,25 @@ RenderCommandListMT::RenderCommandListMT(ParallelRenderCommandListBase& parallel
     META_FUNCTION_TASK();
 }
 
-void RenderCommandListMT::ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group)
+void RenderCommandListMT::Reset(DebugGroup* p_debug_group)
+{
+    META_FUNCTION_TASK();
+    ResetCommandEncoder();
+    RenderCommandListBase::Reset(p_debug_group);
+}
+
+void RenderCommandListMT::ResetWithState(RenderState& render_state, DebugGroup* p_debug_group)
+{
+    META_FUNCTION_TASK();
+    ResetCommandEncoder();
+    RenderCommandListBase::ResetWithState(render_state, p_debug_group);
+}
+
+void RenderCommandListMT::ResetCommandEncoder()
 {
     META_FUNCTION_TASK();
     if (IsCommandEncoderInitialized())
-    {
-        RenderCommandListBase::ResetWithState(render_state_ptr, p_debug_group);
         return;
-    }
 
     if (IsParallel())
     {
@@ -101,8 +112,6 @@ void RenderCommandListMT::ResetWithState(const Ptr<RenderState>& render_state_pt
         id<MTLCommandBuffer>& mtl_cmd_buffer = InitializeCommandBuffer();
         InitializeCommandEncoder([mtl_cmd_buffer renderCommandEncoderWithDescriptor:mtl_render_pass]);
     }
-
-    RenderCommandListBase::ResetWithState(render_state_ptr, p_debug_group);
 }
 
 void RenderCommandListMT::SetVertexBuffers(BufferSet& vertex_buffers)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ObjectBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ObjectBase.cpp
@@ -42,11 +42,13 @@ void ObjectBase::RegistryBase::AddGraphicsObject(Object& object)
     META_FUNCTION_TASK();
     META_CHECK_ARG_NOT_EMPTY_DESCR(object.GetName(), "Can not add graphics object without name to the objects registry.");
 
-    const auto add_result = m_object_by_name.emplace(object.GetName(), object.GetPtr());
-    if (!add_result.second && !add_result.first->second.expired() && add_result.first->second.lock().get() != std::addressof(object))
+    const auto [ name_and_object_it, object_added ] = m_object_by_name.try_emplace(object.GetName(), object.GetPtr());
+    if (!object_added &&
+        !name_and_object_it->second.expired() &&
+         name_and_object_it->second.lock().get() != std::addressof(object))
         throw NameConflictException(object.GetName());
 
-    add_result.first->second = object.GetPtr();
+    name_and_object_it->second = object.GetPtr();
 }
 
 Ptr<Object> ObjectBase::RegistryBase::GetGraphicsObject(const std::string& object_name) const noexcept

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ObjectBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ObjectBase.h
@@ -44,7 +44,7 @@ public:
         bool        HasGraphicsObject(const std::string& object_name) const noexcept override;
 
     private:
-        std::map<std::string, WeakPtr<Object>> m_object_by_name;
+        std::map<std::string, WeakPtr<Object>, std::less<>> m_object_by_name;
     };
 
     ObjectBase() = default;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ParallelRenderCommandListBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ParallelRenderCommandListBase.cpp
@@ -34,13 +34,16 @@ Base implementation of the parallel render command list interface.
 #include <Methane/Data/Math.hpp>
 
 #include <taskflow/taskflow.hpp>
+#include <fmt/format.h>
+
+#include <string_view>
 
 namespace Methane::Graphics
 {
 
-inline std::string GetThreadCommandListName(const std::string& name, Data::Index index)
+inline std::string GetThreadCommandListName(std::string_view name, Data::Index index)
 {
-    return name + " [Thread " + std::to_string(index) + "]";
+    return fmt::format("{} [Thread {}", name, index);
 }
 
 ParallelRenderCommandListBase::ParallelRenderCommandListBase(CommandQueueBase& command_queue, RenderPassBase& render_pass)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ParallelRenderCommandListBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ParallelRenderCommandListBase.cpp
@@ -64,9 +64,33 @@ void ParallelRenderCommandListBase::SetValidationEnabled(bool is_validation_enab
     }
 }
 
-void ParallelRenderCommandListBase::ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group)
+void ParallelRenderCommandListBase::Reset(DebugGroup* p_debug_group)
 {
     META_FUNCTION_TASK();
+    ResetImpl(p_debug_group, [this, p_debug_group](size_t command_list_index)
+    {
+        META_FUNCTION_TASK();
+        const Ptr<RenderCommandList>& render_command_list_ptr = m_parallel_command_lists[command_list_index];
+        META_CHECK_ARG_NOT_NULL(render_command_list_ptr);
+        render_command_list_ptr->Reset(p_debug_group ? p_debug_group->GetSubGroup(static_cast<Data::Index>(command_list_index)) : nullptr);
+    });
+}
+
+void ParallelRenderCommandListBase::ResetWithState(RenderState& render_state, DebugGroup* p_debug_group)
+{
+    META_FUNCTION_TASK();
+    ResetImpl(p_debug_group, [this, &render_state, p_debug_group](size_t command_list_index)
+    {
+        META_FUNCTION_TASK();
+        const Ptr<RenderCommandList>& render_command_list_ptr = m_parallel_command_lists[command_list_index];
+        META_CHECK_ARG_NOT_NULL(render_command_list_ptr);
+        render_command_list_ptr->ResetWithState(render_state, p_debug_group ? p_debug_group->GetSubGroup(static_cast<Data::Index>(command_list_index)) : nullptr);
+    });
+}
+
+template<typename ResetCommandListFn>
+void ParallelRenderCommandListBase::ResetImpl(DebugGroup* p_debug_group, const ResetCommandListFn& reset_command_list_fn)
+{
     CommandListBase::Reset();
 
     // Create per-thread debug sub-group:
@@ -79,18 +103,10 @@ void ParallelRenderCommandListBase::ResetWithState(const Ptr<RenderState>& rende
     }
 
     // Per-thread render command lists can be reset in parallel only with DirectX 12 on Windows
-    const auto reset_command_list_fn = [this, &render_state_ptr, p_debug_group](size_t command_list_index)
-    {
-        META_FUNCTION_TASK();
-        const Ptr<RenderCommandList>& render_command_list_ptr = m_parallel_command_lists[command_list_index];
-        META_CHECK_ARG_NOT_NULL(render_command_list_ptr);
-        render_command_list_ptr->ResetWithState(render_state_ptr, p_debug_group ? p_debug_group->GetSubGroup(static_cast<Data::Index>(command_list_index)) : nullptr);
-    };
-
 #ifdef _WIN32
     tf::Taskflow reset_task_flow;
     reset_task_flow.for_each_index_guided(0, static_cast<int>(m_parallel_command_lists.size()), 1, reset_command_list_fn,
-                                 Data::GetParallelChunkSizeAsInt(m_parallel_command_lists.size()));
+                                          Data::GetParallelChunkSizeAsInt(m_parallel_command_lists.size()));
     GetCommandQueueBase().GetContext().GetParallelExecutor().run(reset_task_flow).get();
 #else
     for(size_t command_list_index = 0U; command_list_index < m_parallel_command_lists.size(); ++command_list_index)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ParallelRenderCommandListBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ParallelRenderCommandListBase.h
@@ -47,7 +47,8 @@ public:
     // ParallelRenderCommandList interface
     bool IsValidationEnabled() const noexcept override { return m_is_validation_enabled; }
     void SetValidationEnabled(bool is_validation_enabled) override;
-    void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) override;
+    void Reset(DebugGroup* p_debug_group = nullptr) override;
+    void ResetWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) override;
     void SetViewState(ViewState& view_state) override;
     void SetParallelCommandListsCount(uint32_t count) override;
     const Ptrs<RenderCommandList>& GetParallelCommandLists() const override { return m_parallel_command_lists; }
@@ -69,6 +70,9 @@ public:
     Ptr<ParallelRenderCommandListBase> GetParallelRenderCommandListPtr() { return std::static_pointer_cast<ParallelRenderCommandListBase>(GetBasePtr()); }
 
 private:
+    template<typename ResetCommandListFn>
+    void ResetImpl(DebugGroup* p_debug_group, const ResetCommandListFn& reset_command_list_fn);
+
     const Ptr<RenderPass>   m_render_pass_ptr;
     Ptrs<RenderCommandList> m_parallel_command_lists;
     bool                    m_is_validation_enabled = true;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.cpp
@@ -128,7 +128,7 @@ ProgramBase::~ProgramBase()
 {
     META_FUNCTION_TASK();
 
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_constant_descriptor_ranges_reservation_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_constant_descriptor_ranges_reservation_mutex);
     for (const auto& [heap_type, heap_reservation] : m_constant_descriptor_range_by_heap_type)
     {
         if (heap_reservation.range.IsEmpty())
@@ -189,7 +189,7 @@ void ProgramBase::InitArgumentBindings(const ArgumentDescriptions& argument_desc
 const DescriptorHeap::Range& ProgramBase::ReserveConstantDescriptorRange(DescriptorHeap& heap, uint32_t range_length)
 {
     META_FUNCTION_TASK();
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_constant_descriptor_ranges_reservation_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_constant_descriptor_ranges_reservation_mutex);
 
     const DescriptorHeap::Type heap_type = heap.GetSettings().type;
     auto constant_descriptor_range_by_heap_type_it = m_constant_descriptor_range_by_heap_type.find(heap_type);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.cpp
@@ -129,9 +129,8 @@ ProgramBase::~ProgramBase()
     META_FUNCTION_TASK();
 
     std::lock_guard<LockableBase(std::mutex)> lock_guard(m_constant_descriptor_ranges_reservation_mutex);
-    for (const auto& heap_type_and_desc_range : m_constant_descriptor_range_by_heap_type)
+    for (const auto& [heap_type, heap_reservation] : m_constant_descriptor_range_by_heap_type)
     {
-        const DescriptorHeapReservation& heap_reservation = heap_type_and_desc_range.second;
         if (heap_reservation.range.IsEmpty())
             continue;
 
@@ -164,13 +163,11 @@ void ProgramBase::InitArgumentBindings(const ArgumentDescriptions& argument_desc
     }
     
     // Replace bindings for argument set for all shader types in program to one binding set for argument with Shader::Type::All
-    for (const auto& shader_types_by_argument_name : shader_types_by_argument_name_map)
+    for (const auto& [argument_name, shader_types] : shader_types_by_argument_name_map)
     {
-        const Shader::Types& shader_types = shader_types_by_argument_name.second;
         if (shader_types != all_shader_types)
             continue;
 
-        const std::string& argument_name = shader_types_by_argument_name.first;
         Ptr<ProgramBindings::ArgumentBinding> argument_binding_ptr;
         for(Shader::Type shader_type : all_shader_types)
         {

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.cpp
@@ -143,7 +143,7 @@ void ProgramBase::InitArgumentBindings(const ArgumentDescriptions& argument_desc
     META_FUNCTION_TASK();
 
     Shader::Types all_shader_types;
-    std::map<std::string, Shader::Types> shader_types_by_argument_name_map;
+    std::map<std::string, Shader::Types, std::less<>> shader_types_by_argument_name_map;
     
     m_binding_by_argument.clear();
     for (const Ptr<Shader>& shader_ptr : m_settings.shaders)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.cpp
@@ -73,9 +73,8 @@ Program::ArgumentDesc::ArgumentDesc(const Argument& argument, Modifiers modifier
 Program::ArgumentDescriptions::const_iterator Program::FindArgumentDescription(const ArgumentDescriptions& argument_descriptions, const Argument& argument)
 {
     META_FUNCTION_TASK();
-
-    Program::ArgumentDescriptions::const_iterator argument_desc_it = argument_descriptions.find(argument);
-    if (argument_desc_it != argument_descriptions.end())
+    if (const auto argument_desc_it = argument_descriptions.find(argument);
+        argument_desc_it != argument_descriptions.end())
         return argument_desc_it;
 
     const Argument all_shaders_argument(Shader::Type::All, argument.name);
@@ -192,8 +191,8 @@ const DescriptorHeap::Range& ProgramBase::ReserveConstantDescriptorRange(Descrip
     std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_constant_descriptor_ranges_reservation_mutex);
 
     const DescriptorHeap::Type heap_type = heap.GetSettings().type;
-    auto constant_descriptor_range_by_heap_type_it = m_constant_descriptor_range_by_heap_type.find(heap_type);
-    if (constant_descriptor_range_by_heap_type_it != m_constant_descriptor_range_by_heap_type.end())
+    if (auto constant_descriptor_range_by_heap_type_it = m_constant_descriptor_range_by_heap_type.find(heap_type);
+        constant_descriptor_range_by_heap_type_it != m_constant_descriptor_range_by_heap_type.end())
     {
         const DescriptorHeapReservation& heap_reservation = constant_descriptor_range_by_heap_type_it->second;
         META_CHECK_ARG_NAME_DESCR("heap", std::addressof(heap) == std::addressof(heap_reservation.heap.get()),
@@ -222,8 +221,8 @@ uint32_t ProgramBase::GetInputBufferIndexByArgumentSemantic(const std::string& a
     for (size_t buffer_index = 0; buffer_index < m_settings.input_buffer_layouts.size(); buffer_index++)
     {
         const InputBufferLayout& input_buffer_layout = m_settings.input_buffer_layouts[buffer_index];
-        auto argument_it = std::find(input_buffer_layout.argument_semantics.begin(), input_buffer_layout.argument_semantics.end(), argument_semantic);
-        if (argument_it != input_buffer_layout.argument_semantics.end())
+        if (auto argument_it = std::find(input_buffer_layout.argument_semantics.begin(), input_buffer_layout.argument_semantics.end(), argument_semantic);
+            argument_it != input_buffer_layout.argument_semantics.end())
             return static_cast<uint32_t>(buffer_index);
     }
     META_INVALID_ARG_DESCR(argument_semantic, "input argument with semantic name was not found for program '{}'", GetName());

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBase.cpp
@@ -158,7 +158,7 @@ void ProgramBase::InitArgumentBindings(const ArgumentDescriptions& argument_desc
         {
             META_CHECK_ARG_NOT_NULL_DESCR(argument_binging_ptr, "empty resource binding provided by shader");
             const Argument& shader_argument = argument_binging_ptr->GetSettings().argument;
-            m_binding_by_argument.emplace(shader_argument, argument_binging_ptr);
+            m_binding_by_argument.try_emplace(shader_argument, argument_binging_ptr);
             shader_types_by_argument_name_map[shader_argument.name].insert(shader_argument.shader_type);
         }
     }
@@ -185,7 +185,7 @@ void ProgramBase::InitArgumentBindings(const ArgumentDescriptions& argument_desc
         }
 
         META_CHECK_ARG_NOT_NULL_DESCR(argument_binding_ptr, "failed to create resource binding for argument '{}'", argument_name);
-        m_binding_by_argument.emplace( Argument{ Shader::Type::All, argument_name }, argument_binding_ptr);
+        m_binding_by_argument.try_emplace( Argument{ Shader::Type::All, argument_name }, argument_binding_ptr);
     }
 }
 
@@ -208,7 +208,7 @@ const DescriptorHeap::Range& ProgramBase::ReserveConstantDescriptorRange(Descrip
 
     DescriptorHeap::Range const_desc_range = heap.ReserveRange(range_length);
     META_CHECK_ARG_NOT_ZERO_DESCR(const_desc_range, "Descriptor heap does not have enough space to reserve constant descriptor range of a program.");
-    return m_constant_descriptor_range_by_heap_type.emplace(heap_type, DescriptorHeapReservation{ heap, const_desc_range }).first->second.range;
+    return m_constant_descriptor_range_by_heap_type.try_emplace(heap_type, DescriptorHeapReservation{ heap, const_desc_range }).first->second.range;
 }
 
 Shader& ProgramBase::GetShaderRef(Shader::Type shader_type)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBindingsBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ProgramBindingsBase.cpp
@@ -155,7 +155,7 @@ ProgramBindingsBase::ProgramBindingsBase(const ProgramBindingsBase& other_progra
             resource_locations_by_argument.count(argument_and_argument_binding.first))
             continue;
 
-        resource_locations_by_argument.emplace(
+        resource_locations_by_argument.try_emplace(
             argument_and_argument_binding.first,
             argument_and_argument_binding.second->GetResourceLocations()
         );
@@ -227,7 +227,7 @@ void ProgramBindingsBase::ReserveDescriptorHeapRanges()
         auto binding_by_argument_it = m_binding_by_argument.find(binding_by_argument.first);
         if (binding_by_argument_it == m_binding_by_argument.end())
         {
-            m_binding_by_argument.emplace(
+            m_binding_by_argument.try_emplace(
                 binding_by_argument.first,
                 binding_settings.argument.IsConstant()
                     ? binding_by_argument.second

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/QueryBuffer.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/QueryBuffer.h
@@ -86,8 +86,8 @@ public:
     Ptr<QueryT> CreateQuery(CommandListBase& command_list)
     {
         META_FUNCTION_TASK();
-        const CreateQueryArgs   query_args = GetCreateQueryArguments();
-        return std::make_shared<QueryT>(*this, command_list, std::get<0>(query_args), std::get<1>(query_args));
+        const auto [query_index, query_range] = GetCreateQueryArguments();
+        return std::make_shared<QueryT>(*this, command_list, query_index, query_range);
     }
 
     Ptr<QueryBuffer>  GetPtr()                       { return shared_from_this(); }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/QueryBuffer.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/QueryBuffer.h
@@ -66,11 +66,11 @@ public:
         virtual void ResolveData();
         virtual Resource::SubResource GetData() = 0;
 
-        Index            GetIndex() const noexcept       { return m_index; }
-        const Range&     GetDataRange() const noexcept   { return m_data_range; }
-        State            GetState() const noexcept       { return m_state; }
-        QueryBuffer&     GetQueryBuffer() const noexcept { return *m_buffer_ptr; }
-        CommandListBase& GetCommandList() const noexcept { return m_command_list; }
+        [[nodiscard]] Index            GetIndex() const noexcept       { return m_index; }
+        [[nodiscard]] const Range&     GetDataRange() const noexcept   { return m_data_range; }
+        [[nodiscard]] State            GetState() const noexcept       { return m_state; }
+        [[nodiscard]] QueryBuffer&     GetQueryBuffer() const noexcept { return *m_buffer_ptr; }
+        [[nodiscard]] CommandListBase& GetCommandList() const noexcept { return m_command_list; }
 
     private:
         Ptr<QueryBuffer> m_buffer_ptr;
@@ -83,19 +83,19 @@ public:
     virtual ~QueryBuffer() = default;
 
     template<typename QueryT>
-    Ptr<QueryT> CreateQuery(CommandListBase& command_list)
+    [[nodiscard]] Ptr<QueryT> CreateQuery(CommandListBase& command_list)
     {
         META_FUNCTION_TASK();
         const auto [query_index, query_range] = GetCreateQueryArguments();
         return std::make_shared<QueryT>(*this, command_list, query_index, query_range);
     }
 
-    Ptr<QueryBuffer>  GetPtr()                       { return shared_from_this(); }
-    Type              GetType() const noexcept       { return m_type; }
-    Data::Size        GetBufferSize() const noexcept { return m_buffer_size; }
-    Data::Size        GetQuerySize() const noexcept  { return m_query_size; }
-    CommandQueueBase& GetCommandQueueBase() noexcept { return m_command_queue; }
-    Context&          GetContext() noexcept          { return m_context; }
+    [[nodiscard]] Ptr<QueryBuffer>  GetPtr()                       { return shared_from_this(); }
+    [[nodiscard]] Type              GetType() const noexcept       { return m_type; }
+    [[nodiscard]] Data::Size        GetBufferSize() const noexcept { return m_buffer_size; }
+    [[nodiscard]] Data::Size        GetQuerySize() const noexcept  { return m_query_size; }
+    [[nodiscard]] CommandQueueBase& GetCommandQueueBase() noexcept { return m_command_queue; }
+    [[nodiscard]] Context&          GetContext() noexcept          { return m_context; }
 
 protected:
     QueryBuffer(CommandQueueBase& command_queue, Type type,
@@ -105,7 +105,7 @@ protected:
     virtual void ReleaseQuery(const Query& query);
 
     using CreateQueryArgs = std::tuple<Query::Index, Query::Range>;
-    CreateQueryArgs GetCreateQueryArguments();
+    [[nodiscard]] CreateQueryArgs GetCreateQueryArguments();
 
 private:
     using RangeSet = Data::RangeSet<Data::Index>;
@@ -125,15 +125,16 @@ struct TimestampQueryBuffer
     {
         virtual void InsertTimestamp() = 0;
         virtual void ResolveTimestamp() = 0;
-        virtual Timestamp GetGpuTimestamp() = 0;
-        virtual Timestamp GetCpuNanoseconds() = 0;
+
+        [[nodiscard]] virtual Timestamp GetGpuTimestamp() = 0;
+        [[nodiscard]] virtual Timestamp GetCpuNanoseconds() = 0;
 
         virtual ~TimestampQuery() = default;
     };
 
-    static Ptr<TimestampQueryBuffer> Create(CommandQueueBase& command_queue, uint32_t max_timestamps_per_frame);
+    [[nodiscard]] static Ptr<TimestampQueryBuffer> Create(CommandQueueBase& command_queue, uint32_t max_timestamps_per_frame);
 
-    virtual Ptr<TimestampQuery> CreateTimestampQuery(CommandListBase& command_list) = 0;
+    [[nodiscard]] virtual Ptr<TimestampQuery> CreateTimestampQuery(CommandListBase& command_list) = 0;
 
     virtual ~TimestampQueryBuffer() = default;
 };

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.cpp
@@ -67,7 +67,7 @@ void RenderCommandListBase::ResetWithState(RenderState& render_state, DebugGroup
     SetRenderState(render_state);
 }
 
-void RenderCommandListBase::ResetOnceWithState(RenderState& render_state, DebugGroup* p_debug_group)
+void RenderCommandListBase::ResetWithStateOnce(RenderState& render_state, DebugGroup* p_debug_group)
 {
     META_FUNCTION_TASK();
     if (GetState() == State::Encoding && GetDrawingState().render_state_ptr.get() == std::addressof(render_state))

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.cpp
@@ -67,6 +67,18 @@ void RenderCommandListBase::ResetWithState(const Ptr<RenderState>& render_state_
     }
 }
 
+void RenderCommandListBase::ResetOnceWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group)
+{
+    META_FUNCTION_TASK();
+    if (GetState() == State::Encoding && GetDrawingState().render_state_ptr.get() == render_state_ptr.get())
+    {
+        META_LOG("{} Command list '{}' was already RESET with the same render state", magic_enum::enum_name(GetType()), GetName());
+        return;
+    }
+
+    ResetWithState(render_state_ptr, p_debug_group);
+}
+
 void RenderCommandListBase::SetRenderState(RenderState& render_state, RenderState::Groups state_groups)
 {
     META_FUNCTION_TASK();

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.cpp
@@ -53,30 +53,29 @@ RenderCommandListBase::RenderCommandListBase(ParallelRenderCommandListBase& para
     META_FUNCTION_TASK();
 }
 
-void RenderCommandListBase::ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group)
+void RenderCommandListBase::Reset(DebugGroup* p_debug_group)
 {
     META_FUNCTION_TASK();
-
     CommandListBase::Reset(p_debug_group);
-
     m_drawing_state.render_pass_attachments_ptr = m_render_pass_ptr->GetNonFrameBufferAttachmentTextures();
-
-    if (render_state_ptr)
-    {
-        SetRenderState(*render_state_ptr);
-    }
 }
 
-void RenderCommandListBase::ResetOnceWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group)
+void RenderCommandListBase::ResetWithState(RenderState& render_state, DebugGroup* p_debug_group)
 {
     META_FUNCTION_TASK();
-    if (GetState() == State::Encoding && GetDrawingState().render_state_ptr.get() == render_state_ptr.get())
+    RenderCommandListBase::Reset(p_debug_group);
+    SetRenderState(render_state);
+}
+
+void RenderCommandListBase::ResetOnceWithState(RenderState& render_state, DebugGroup* p_debug_group)
+{
+    META_FUNCTION_TASK();
+    if (GetState() == State::Encoding && GetDrawingState().render_state_ptr.get() == std::addressof(render_state))
     {
         META_LOG("{} Command list '{}' was already RESET with the same render state", magic_enum::enum_name(GetType()), GetName());
         return;
     }
-
-    ResetWithState(render_state_ptr, p_debug_group);
+    ResetWithState(render_state, p_debug_group);
 }
 
 void RenderCommandListBase::SetRenderState(RenderState& render_state, RenderState::Groups state_groups)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.h
@@ -75,7 +75,7 @@ public:
     RenderPass& GetRenderPass() const noexcept override                     { return *m_render_pass_ptr; }
     void Reset(DebugGroup* p_debug_group = nullptr) override;
     void ResetWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) override;
-    void ResetOnceWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) final;
+    void ResetWithStateOnce(RenderState& render_state, DebugGroup* p_debug_group = nullptr) final;
     void SetRenderState(RenderState& render_state, RenderState::Groups state_groups = RenderState::Groups::All) override;
     void SetViewState(ViewState& view_state) override;
     void SetVertexBuffers(BufferSet& vertex_buffers) override;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.h
@@ -74,6 +74,7 @@ public:
     void SetValidationEnabled(bool is_validation_enabled) override          { m_is_validation_enabled = is_validation_enabled; }
     RenderPass& GetRenderPass() const noexcept override                     { return *m_render_pass_ptr; }
     void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) override;
+    void ResetOnceWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) final;
     void SetRenderState(RenderState& render_state, RenderState::Groups state_groups = RenderState::Groups::All) override;
     void SetViewState(ViewState& view_state) override;
     void SetVertexBuffers(BufferSet& vertex_buffers) override;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/RenderCommandListBase.h
@@ -73,8 +73,9 @@ public:
     bool IsValidationEnabled() const noexcept override                      { return m_is_validation_enabled; }
     void SetValidationEnabled(bool is_validation_enabled) override          { m_is_validation_enabled = is_validation_enabled; }
     RenderPass& GetRenderPass() const noexcept override                     { return *m_render_pass_ptr; }
-    void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) override;
-    void ResetOnceWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) final;
+    void Reset(DebugGroup* p_debug_group = nullptr) override;
+    void ResetWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) override;
+    void ResetOnceWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) final;
     void SetRenderState(RenderState& render_state, RenderState::Groups state_groups = RenderState::Groups::All) override;
     void SetViewState(ViewState& view_state) override;
     void SetVertexBuffers(BufferSet& vertex_buffers) override;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/RenderPassBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/RenderPassBase.cpp
@@ -164,8 +164,8 @@ void RenderPassBase::SetAttachmentStates(const std::optional<ResourceBase::State
 
     if (depth_state)
     {
-        TextureBase* p_depth_texture = GetDepthAttachmentTexture();
-        if (p_depth_texture)
+        if (TextureBase* p_depth_texture = GetDepthAttachmentTexture();
+            p_depth_texture)
         {
             attachment_states_changed |= p_depth_texture->SetState(*depth_state, transition_barriers_ptr);
         }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/RenderStateBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/RenderStateBase.cpp
@@ -199,7 +199,19 @@ RenderState::Groups RenderState::Settings::Compare(const Settings& left, const S
     
     return changed_state_groups;
 }
-    
+
+bool RenderState::Settings::operator==(const Settings& other) const noexcept
+{
+    return std::tie(program_ptr, rasterizer, depth, stencil, blending, blending_color) ==
+           std::tie(other.program_ptr, other.rasterizer, other.depth, other.stencil, other.blending, other.blending_color);
+}
+
+bool RenderState::Settings::operator!=(const Settings& other) const noexcept
+{
+    return std::tie(program_ptr, rasterizer, depth, stencil, blending, blending_color) !=
+           std::tie(other.program_ptr, other.rasterizer, other.depth, other.stencil, other.blending, other.blending_color);
+}
+
 RenderStateBase::RenderStateBase(RenderContextBase& context, const Settings& settings)
     : m_context(context)
     , m_settings(settings)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
@@ -424,8 +424,8 @@ void ResourceBase::InitializeDefaultDescriptors()
         if (!magic_enum::flags::enum_contains(usage & m_usage_mask))
             continue;
 
-        auto descriptor_by_usage_it = m_descriptor_by_usage.find(usage);
-        if (descriptor_by_usage_it == m_descriptor_by_usage.end())
+        if (const auto descriptor_by_usage_it = m_descriptor_by_usage.find(usage);
+            descriptor_by_usage_it == m_descriptor_by_usage.end())
         {
             // Create default resource descriptor by usage
             const DescriptorHeap::Type heap_type = GetDescriptorHeapTypeByUsage(usage);

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
@@ -207,13 +207,13 @@ bool ResourceBase::Barriers::AddTransition(const Resource& resource, State befor
 bool ResourceBase::Barriers::AddStateChange(const Barrier::Id& id, const Barrier::StateChange& state_change)
 {
     META_FUNCTION_TASK();
-    const auto emplace_result = m_barriers_map.emplace(id, state_change);
-    if (emplace_result.second)
+    const auto [ barrier_id_and_state_change_it, barrier_added ] = m_barriers_map.try_emplace(id, state_change);
+    if (barrier_added)
         return true;
-    else if (emplace_result.first->second == state_change)
+    else if (barrier_id_and_state_change_it->second == state_change)
         return false;
 
-    emplace_result.first->second = state_change;
+    barrier_id_and_state_change_it->second = state_change;
     return true;
 }
 
@@ -430,7 +430,7 @@ void ResourceBase::InitializeDefaultDescriptors()
             // Create default resource descriptor by usage
             const DescriptorHeap::Type heap_type = GetDescriptorHeapTypeByUsage(usage);
             DescriptorHeap& heap = m_context.GetResourceManager().GetDescriptorHeap(heap_type);
-            m_descriptor_by_usage.emplace(usage, Descriptor(heap, heap.AddResource(*this)));
+            m_descriptor_by_usage.try_emplace(usage, Descriptor(heap, heap.AddResource(*this)));
         }
     }
 }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
@@ -399,9 +399,9 @@ ResourceBase::ResourceBase(Type type, Usage usage_mask, ContextBase& context, co
 {
     META_FUNCTION_TASK();
 
-    for (auto& usage_and_descriptor : m_descriptor_by_usage)
+    for (const auto& [usage, descriptor] : m_descriptor_by_usage)
     {
-        usage_and_descriptor.second.heap.ReplaceResource(*this, usage_and_descriptor.second.index);
+        descriptor.heap.ReplaceResource(*this, descriptor.index);
     }
 }
 
@@ -409,9 +409,9 @@ ResourceBase::~ResourceBase()
 {
     META_FUNCTION_TASK();
 
-    for (const auto& usage_and_descriptor : m_descriptor_by_usage)
+    for (const auto& [usage, descriptor] : m_descriptor_by_usage)
     {
-        usage_and_descriptor.second.heap.RemoveResource(usage_and_descriptor.second.index);
+        descriptor.heap.RemoveResource(descriptor.index);
     }
 }
 
@@ -531,9 +531,9 @@ DescriptorHeap::Types ResourceBase::GetUsedDescriptorHeapTypes() const noexcept
 {
     META_FUNCTION_TASK();
     DescriptorHeap::Types heap_types;
-    for (auto usage_and_descriptor : m_descriptor_by_usage)
+    for (const auto& [usage, descriptor] : m_descriptor_by_usage)
     {
-        heap_types.insert(usage_and_descriptor.second.heap.GetSettings().type);
+        heap_types.insert(descriptor.heap.GetSettings().type);
     }
     return heap_types;
 }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
@@ -544,7 +544,7 @@ bool ResourceBase::SetState(State state, Ptr<Barriers>& out_barriers)
     if (m_state == state)
         return false;
 
-    META_LOG("Resource '{}' state changed from {} to {}", GetName(), GetStateName(m_state), GetStateName(state));
+    META_LOG("Resource '{}' state changed from {} to {}", GetName(), magic_enum::enum_name(m_state), magic_enum::enum_name(state));
 
     if (m_state != State::Common)
     {

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.cpp
@@ -142,12 +142,12 @@ Ptr<ResourceBase::Barriers> ResourceBase::Barriers::CreateTransition(const Refs<
     std::set<Barrier> resource_barriers;
     for (const Ref<const Resource>& resource_ref : resources)
     {
-        resource_barriers.emplace(Barrier{
+        resource_barriers.emplace(
             ResourceBase::Barrier::Type::Transition,
             resource_ref.get(),
             state_before,
             state_after
-        });
+        );
     }
     return Barriers::Create(resource_barriers);
 }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceBase.h
@@ -38,7 +38,7 @@ class ContextBase;
 
 struct IResourceBase
 {
-    virtual DescriptorHeap::Types GetUsedDescriptorHeapTypes() const noexcept = 0;
+    [[nodiscard]] virtual DescriptorHeap::Types GetUsedDescriptorHeapTypes() const noexcept = 0;
 
     virtual ~IResourceBase() = default;
 };
@@ -86,12 +86,12 @@ public:
 
             Id& operator=(const Id&) noexcept = default;
 
-            bool operator<(const Id& other) const noexcept;
-            bool operator==(const Id& other) const noexcept;
-            bool operator!=(const Id& other) const noexcept;
+            [[nodiscard]] bool operator<(const Id& other) const noexcept;
+            [[nodiscard]] bool operator==(const Id& other) const noexcept;
+            [[nodiscard]] bool operator!=(const Id& other) const noexcept;
 
-            Type            GetType() const noexcept     { return m_type; }
-            const Resource& GetResource() const noexcept { return m_resource_ref.get(); }
+            [[nodiscard]] Type            GetType() const noexcept     { return m_type; }
+            [[nodiscard]] const Resource& GetResource() const noexcept { return m_resource_ref.get(); }
 
         private:
             Type                m_type;
@@ -106,12 +106,12 @@ public:
 
             StateChange& operator=(const StateChange&) noexcept = default;
 
-            bool operator<(const StateChange& other) const noexcept;
-            bool operator==(const StateChange& other) const noexcept;
-            bool operator!=(const StateChange& other) const noexcept;
+            [[nodiscard]] bool operator<(const StateChange& other) const noexcept;
+            [[nodiscard]] bool operator==(const StateChange& other) const noexcept;
+            [[nodiscard]] bool operator!=(const StateChange& other) const noexcept;
 
-            State GetStateBefore() const noexcept { return m_before; }
-            State GetStateAfter() const noexcept  { return m_after; }
+            [[nodiscard]] State GetStateBefore() const noexcept { return m_before; }
+            [[nodiscard]] State GetStateAfter() const noexcept  { return m_after; }
 
         private:
             State m_before;
@@ -123,13 +123,13 @@ public:
         Barrier(const Barrier&) = default;
 
         Barrier& operator=(const Barrier& barrier) noexcept = default;
-        bool operator<(const Barrier& other) const noexcept;
-        bool operator==(const Barrier& other) const noexcept;
-        bool operator!=(const Barrier& other) const noexcept;
-        explicit operator std::string() const noexcept;
+        [[nodiscard]] bool operator<(const Barrier& other) const noexcept;
+        [[nodiscard]] bool operator==(const Barrier& other) const noexcept;
+        [[nodiscard]] bool operator!=(const Barrier& other) const noexcept;
+        [[nodiscard]] explicit operator std::string() const noexcept;
 
-        const Id&          GetId() const noexcept          { return m_id; }
-        const StateChange& GetStateChange() const noexcept { return m_state_change; }
+        [[nodiscard]] const Id&          GetId() const noexcept          { return m_id; }
+        [[nodiscard]] const StateChange& GetStateChange() const noexcept { return m_state_change; }
 
     private:
         Id          m_id;
@@ -142,22 +142,23 @@ public:
         using Set = std::set<Barrier>;
         using Map = std::map<Barrier::Id, Barrier::StateChange>;
 
-        static Ptr<Barriers> Create(const Set& barriers = {});
-        static Ptr<Barriers> CreateTransition(const Refs<const Resource>& resources, State state_before, State state_after);
+        [[nodiscard]] static Ptr<Barriers> Create(const Set& barriers = {});
+        [[nodiscard]] static Ptr<Barriers> CreateTransition(const Refs<const Resource>& resources, State state_before, State state_after);
 
-        bool       IsEmpty() const noexcept { return m_barriers_map.empty(); }
-        const Map& GetMap() const noexcept  { return m_barriers_map; }
-        Set        GetSet() const noexcept;
+        [[nodiscard]] bool       IsEmpty() const noexcept { return m_barriers_map.empty(); }
+        [[nodiscard]] const Map& GetMap() const noexcept  { return m_barriers_map; }
+        [[nodiscard]] Set        GetSet() const noexcept;
 
-        bool Has(Barrier::Type type, const Resource& resource, State before, State after);
-        bool HasTransition(const Resource& resource, State before, State after);
+        [[nodiscard]] bool Has(Barrier::Type type, const Resource& resource, State before, State after);
+        [[nodiscard]] bool HasTransition(const Resource& resource, State before, State after);
+
         bool Add(Barrier::Type type, const Resource& resource, State before, State after);
         bool AddTransition(const Resource& resource, State before, State after);
         virtual bool AddStateChange(const Barrier::Id& id, const Barrier::StateChange& state_change);
 
         virtual ~Barriers() = default;
 
-        explicit operator std::string() const noexcept;
+        [[nodiscard]] explicit operator std::string() const noexcept;
 
     protected:
         explicit Barriers(const Set& barriers);
@@ -172,34 +173,35 @@ public:
     ~ResourceBase() override;
 
     // Resource interface
-    Type                      GetResourceType() const noexcept final             { return m_type; }
-    Usage                     GetUsage() const noexcept final                    { return m_usage_mask; }
-    const DescriptorByUsage&  GetDescriptorByUsage() const noexcept final        { return m_descriptor_by_usage; }
-    const Descriptor&         GetDescriptor(Usage usage) const final;
-    void                      SetData(const SubResources& sub_resources) override;
-    SubResource               GetData(const SubResource::Index& sub_resource_index = SubResource::Index(), const std::optional<BytesRange>& data_range = {}) override;
-    const SubResource::Count& GetSubresourceCount() const noexcept final         { return m_sub_resource_count; }
-    Data::Size                GetSubResourceDataSize(const SubResource::Index& subresource_index = SubResource::Index()) const final;
-    Context&                  GetContext() noexcept final;
+    [[nodiscard]] Type                      GetResourceType() const noexcept final             { return m_type; }
+    [[nodiscard]] Usage                     GetUsage() const noexcept final                    { return m_usage_mask; }
+    [[nodiscard]] const DescriptorByUsage&  GetDescriptorByUsage() const noexcept final        { return m_descriptor_by_usage; }
+    [[nodiscard]] const Descriptor&         GetDescriptor(Usage usage) const final;
+    [[nodiscard]] Context&                  GetContext() noexcept final;
+    [[nodiscard]] const SubResource::Count& GetSubresourceCount() const noexcept final         { return m_sub_resource_count; }
+    [[nodiscard]] Data::Size                GetSubResourceDataSize(const SubResource::Index& subresource_index = SubResource::Index()) const final;
+    [[nodiscard]] SubResource               GetData(const SubResource::Index& sub_resource_index = SubResource::Index(), const std::optional<BytesRange>& data_range = {}) override;
+    void SetData(const SubResources& sub_resources) override;
 
-    void                      InitializeDefaultDescriptors();
-    DescriptorHeap::Types     GetUsedDescriptorHeapTypes() const noexcept;
+    void InitializeDefaultDescriptors();
+    [[nodiscard]] DescriptorHeap::Types GetUsedDescriptorHeapTypes() const noexcept;
 
-    State   GetState() const noexcept                                            { return m_state;  }
-    bool    SetState(State state, Ptr<Barriers>& out_barriers);
+    [[nodiscard]] State GetState() const noexcept { return m_state;  }
+    bool SetState(State state, Ptr<Barriers>& out_barriers);
 
-    static const std::vector<Resource::Usage>& GetPrimaryUsageValues() noexcept;
+    [[nodiscard]] static const std::vector<Resource::Usage>& GetPrimaryUsageValues() noexcept;
 
 protected:
-    ContextBase&         GetContextBase()                                       { return m_context; }
-    DescriptorHeap::Type GetDescriptorHeapTypeByUsage(Usage usage) const;
-    const Descriptor&    GetDescriptorByUsage(Usage usage) const;
-    Data::Size           GetInitializedDataSize() const noexcept                { return m_initialized_data_size; }
+    [[nodiscard]] ContextBase&         GetContextBase()                                       { return m_context; }
+    [[nodiscard]] DescriptorHeap::Type GetDescriptorHeapTypeByUsage(Usage usage) const;
+    [[nodiscard]] const Descriptor&    GetDescriptorByUsage(Usage usage) const;
+    [[nodiscard]] Data::Size           GetInitializedDataSize() const noexcept                { return m_initialized_data_size; }
+
     void                 SetSubResourceCount(const SubResource::Count& sub_resource_count);
     void                 ValidateSubResource(const SubResource& sub_resource) const;
     void                 ValidateSubResource(const SubResource::Index& sub_resource_index, const std::optional<BytesRange>& sub_resource_data_range) const;
 
-    virtual Data::Size   CalculateSubResourceDataSize(const SubResource::Index& sub_resource_index) const;
+    [[nodiscard]] virtual Data::Size CalculateSubResourceDataSize(const SubResource::Index& sub_resource_index) const;
 
 private:
     using SubResourceSizes = std::vector<Data::Size>;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceManager.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceManager.cpp
@@ -80,7 +80,7 @@ void ResourceManager::CompleteInitialization()
     if (!IsDeferredHeapAllocation())
         return;
 
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_program_bindings_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_program_bindings_mutex);
 
     for (const Ptrs<DescriptorHeap>& desc_heaps : m_descriptor_heap_types)
     {
@@ -138,7 +138,7 @@ void ResourceManager::AddProgramBindings(ProgramBindings& program_bindings)
 {
     META_FUNCTION_TASK();
 
-    std::lock_guard<LockableBase(std::mutex)> lock_guard(m_program_bindings_mutex);
+    std::scoped_lock<LockableBase(std::mutex)> lock_guard(m_program_bindings_mutex);
 #ifdef _DEBUG
     // This may cause performance drop on adding massive amount of program bindings,
     // so we assume that only different program bindings are added and check it in Debug builds only

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceManager.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ResourceManager.h
@@ -59,16 +59,16 @@ public:
     void Release();
 
     void SetDeferredHeapAllocation(bool deferred_heap_allocation);
-    bool IsDeferredHeapAllocation() const { return m_deferred_heap_allocation; }
+    [[nodiscard]] bool IsDeferredHeapAllocation() const { return m_deferred_heap_allocation; }
 
     void AddProgramBindings(ProgramBindings& program_bindings);
 
-    uint32_t                    CreateDescriptorHeap(const DescriptorHeap::Settings& settings); // returns index of the created descriptor heap
-    const Ptr<DescriptorHeap>&  GetDescriptorHeapPtr(DescriptorHeap::Type type, Data::Index heap_index = 0);
-    DescriptorHeap&             GetDescriptorHeap(DescriptorHeap::Type type, Data::Index heap_index = 0);
-    const Ptr<DescriptorHeap>&  GetDefaultShaderVisibleDescriptorHeapPtr(DescriptorHeap::Type type) const;
-    DescriptorHeap&             GetDefaultShaderVisibleDescriptorHeap(DescriptorHeap::Type type) const;
-    DescriptorHeapSizeByType    GetDescriptorHeapSizes(bool get_allocated_size, bool for_shader_visible_heaps) const;
+    [[nodiscard]] uint32_t                    CreateDescriptorHeap(const DescriptorHeap::Settings& settings); // returns index of the created descriptor heap
+    [[nodiscard]] const Ptr<DescriptorHeap>&  GetDescriptorHeapPtr(DescriptorHeap::Type type, Data::Index heap_index = 0);
+    [[nodiscard]] DescriptorHeap&             GetDescriptorHeap(DescriptorHeap::Type type, Data::Index heap_index = 0);
+    [[nodiscard]] const Ptr<DescriptorHeap>&  GetDefaultShaderVisibleDescriptorHeapPtr(DescriptorHeap::Type type) const;
+    [[nodiscard]] DescriptorHeap&             GetDefaultShaderVisibleDescriptorHeap(DescriptorHeap::Type type) const;
+    [[nodiscard]] DescriptorHeapSizeByType    GetDescriptorHeapSizes(bool get_allocated_size, bool for_shader_visible_heaps) const;
 
 private:
     template<typename FuncType> // function void(DescriptorHeap& descriptor_heap)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ShaderBase.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ShaderBase.cpp
@@ -30,7 +30,7 @@ Base implementation of the shader interface.
 namespace Methane::Graphics
 {
 
-std::string Shader::ConvertMacroDefinitionsToString(const MacroDefinitions& macro_definitions, const std::string& splitter) noexcept
+std::string Shader::ConvertMacroDefinitionsToString(const MacroDefinitions& macro_definitions, std::string_view splitter) noexcept
 {
     META_FUNCTION_TASK();
     std::stringstream ss;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/ShaderBase.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/ShaderBase.h
@@ -29,6 +29,8 @@ Base implementation of the shader interface.
 
 #include <Methane/Graphics/Shader.h>
 
+#include <string_view>
+
 namespace Methane::Graphics
 {
 
@@ -51,7 +53,7 @@ public:
     using ArgumentBindings = Ptrs<ProgramBindingsBase::ArgumentBindingBase>;
     virtual ArgumentBindings GetArgumentBindings(const Program::ArgumentDescriptions& argument_descriptions) const = 0;
 
-    Ptr<ShaderBase> GetPtr()                { return shared_from_this(); }
+    Ptr<ShaderBase> GetPtr() { return shared_from_this(); }
 
 protected:
     ContextBase&        GetContext()        { return m_context; }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ParallelRenderCommandListVK.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ParallelRenderCommandListVK.cpp
@@ -47,15 +47,19 @@ ParallelRenderCommandListVK::ParallelRenderCommandListVK(CommandQueueBase& comma
 void ParallelRenderCommandListVK::SetName(const std::string& name)
 {
     META_FUNCTION_TASK();
-
     ParallelRenderCommandListBase::SetName(name);
 }
 
-void ParallelRenderCommandListVK::ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group)
+void ParallelRenderCommandListVK::Reset(DebugGroup* p_debug_group)
 {
     META_FUNCTION_TASK();
+    ParallelRenderCommandListBase::Reset(p_debug_group);
+}
 
-    ParallelRenderCommandListBase::ResetWithState(render_state_ptr, p_debug_group);
+void ParallelRenderCommandListVK::ResetWithState(RenderState& render_state, DebugGroup* p_debug_group)
+{
+    META_FUNCTION_TASK();
+    ParallelRenderCommandListBase::ResetWithState(render_state, p_debug_group);
 }
 
 void ParallelRenderCommandListVK::Commit()

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ParallelRenderCommandListVK.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ParallelRenderCommandListVK.h
@@ -38,7 +38,8 @@ public:
     ParallelRenderCommandListVK(CommandQueueBase& command_queue, RenderPassBase& render_pass);
 
     // ParallelRenderCommandList interface
-    void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) override;
+    void Reset(DebugGroup* p_debug_group = nullptr) override;
+    void ResetWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) override;
 
     // CommandList interface
     void Commit() override;

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ParallelRenderCommandListVK.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ParallelRenderCommandListVK.h
@@ -49,7 +49,7 @@ public:
     // Object interface
     void SetName(const std::string& label) override;
 
-protected:
+private:
     CommandQueueVK& GetCommandQueueVK() noexcept;
     RenderPassVK&   GetPassVK();
 };

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ProgramBindingsVK.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ProgramBindingsVK.cpp
@@ -82,14 +82,14 @@ void ProgramBindingsVK::Apply(CommandListBase& command_list, ApplyBehavior apply
 
     auto& vulkan_command_list = static_cast<RenderCommandListVK&>(command_list);
 
-    for(const auto& binding_by_argument : GetArgumentBindings())
+    for(const auto& [program_argument, argument_binding_ptr] : GetArgumentBindings())
     {
-        const auto& vulkan_argument_binding = static_cast<const ProgramBindingsVK::ArgumentBindingVK&>(*binding_by_argument.second);
         if ((magic_enum::flags::enum_contains(apply_behavior & ApplyBehavior::ConstantOnce) ||
              magic_enum::flags::enum_contains(apply_behavior & ApplyBehavior::ChangesOnly)) &&
              vulkan_command_list.GetProgramBindings() &&
-             vulkan_argument_binding.IsAlreadyApplied(GetProgram(), *vulkan_command_list.GetProgramBindings(),
-                                                      magic_enum::flags::enum_contains(apply_behavior & ApplyBehavior::ChangesOnly)))
+             static_cast<const ProgramBindingsVK::ArgumentBindingVK&>(*argument_binding_ptr).IsAlreadyApplied(
+                 GetProgram(), *vulkan_command_list.GetProgramBindings(),
+                 magic_enum::flags::enum_contains(apply_behavior & ApplyBehavior::ChangesOnly)))
             continue;
     }
 }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ProgramVK.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/ProgramVK.h
@@ -39,7 +39,7 @@ public:
 
     ShaderVK& GetShaderVK(Shader::Type shader_type) noexcept;
 
-protected:
+private:
     IContextVK& GetContextVK() noexcept;
 };
 

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderCommandListVK.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderCommandListVK.cpp
@@ -61,12 +61,18 @@ RenderCommandListVK::RenderCommandListVK(ParallelRenderCommandListBase& parallel
     META_FUNCTION_TASK();
 }
 
-void RenderCommandListVK::ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group)
+void RenderCommandListVK::Reset(DebugGroup* p_debug_group)
 {
     META_FUNCTION_TASK();
-
     RenderCommandListBase::ResetCommandState();
-    RenderCommandListBase::ResetWithState(render_state_ptr, p_debug_group);
+    RenderCommandListBase::Reset(p_debug_group);
+}
+
+void RenderCommandListVK::ResetWithState(RenderState& render_state, DebugGroup* p_debug_group)
+{
+    META_FUNCTION_TASK();
+    RenderCommandListBase::ResetCommandState();
+    RenderCommandListBase::ResetWithState(render_state, p_debug_group);
 }
 
 void RenderCommandListVK::SetName(const std::string& name)

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderCommandListVK.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderCommandListVK.h
@@ -50,7 +50,8 @@ public:
     void Execute(uint32_t frame_index, const CompletedCallback& completed_callback = {}) override;
 
     // RenderCommandList interface
-    void ResetWithState(const Ptr<RenderState>& render_state_ptr, DebugGroup* p_debug_group = nullptr) override;
+    void Reset(DebugGroup* p_debug_group = nullptr) override;
+    void ResetWithState(RenderState& render_state, DebugGroup* p_debug_group = nullptr) override;
     void SetVertexBuffers(BufferSet& vertex_buffers) override;
     void DrawIndexed(Primitive primitive, Buffer& index_buffer,
                      uint32_t index_count, uint32_t start_index, uint32_t start_vertex,

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderPassVK.cpp
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderPassVK.cpp
@@ -56,14 +56,12 @@ bool RenderPassVK::Update(const Settings& settings)
 void RenderPassVK::Reset()
 {
     META_FUNCTION_TASK();
-
     uint32_t color_attach_index = 0;
     for(const ColorAttachment& color_attach : GetSettings().color_attachments)
     {
         META_CHECK_ARG_NOT_NULL_DESCR(color_attach.texture_location.IsInitialized(), "can not use color attachment without texture");
-
-        auto& color_texture = static_cast<TextureVK&>(color_attach.texture_location.GetTexture());
-        if (color_texture.GetSettings().type == Texture::Type::FrameBuffer)
+        if (auto& color_texture = static_cast<TextureVK&>(color_attach.texture_location.GetTexture());
+            color_texture.GetSettings().type == Texture::Type::FrameBuffer)
         {
             color_texture.UpdateFrameBuffer();
         }

--- a/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderPassVK.h
+++ b/Modules/Graphics/Core/Sources/Methane/Graphics/Vulkan/RenderPassVK.h
@@ -40,7 +40,7 @@ public:
     
     void Reset();
 
-protected:
+private:
     IContextVK& GetContextVK() noexcept;
 };
 

--- a/Modules/Graphics/Extensions/Include/Methane/Graphics/ImageLoader.h
+++ b/Modules/Graphics/Extensions/Include/Methane/Graphics/ImageLoader.h
@@ -46,7 +46,7 @@ public:
         All             = ~0U
     };
 
-    class ImageData
+    class ImageData // NOSONAR
     {
     public:
         ImageData(const Dimensions& dimensions, uint32_t channels_count, Data::Chunk&& pixels) noexcept;
@@ -54,9 +54,9 @@ public:
         ImageData(const ImageData& other) noexcept = delete;
         ~ImageData();
 
-        const Dimensions&  GetDimensions() const noexcept    { return m_dimensions; }
-        uint32_t           GetChannelsCount() const noexcept { return m_channels_count; }
-        const Data::Chunk& GetPixels() const noexcept        { return m_pixels; }
+        [[nodiscard]] const Dimensions&  GetDimensions() const noexcept    { return m_dimensions; }
+        [[nodiscard]] uint32_t           GetChannelsCount() const noexcept { return m_channels_count; }
+        [[nodiscard]] const Data::Chunk& GetPixels() const noexcept        { return m_pixels; }
 
     private:
         Dimensions  m_dimensions;
@@ -79,10 +79,9 @@ public:
 
     explicit ImageLoader(Data::Provider& data_provider);
 
-    ImageData LoadImage(const std::string& image_path, size_t channels_count, bool create_copy) const;
-
-    Ptr<Texture> LoadImageToTexture2D(Context& context, const std::string& image_path, Options options = Options::None) const;
-    Ptr<Texture> LoadImagesToTextureCube(Context& context, const CubeFaceResources& image_paths, Options options = Options::None) const;
+    [[nodiscard]] ImageData    LoadImage(const std::string& image_path, size_t channels_count, bool create_copy) const;
+    [[nodiscard]] Ptr<Texture> LoadImageToTexture2D(Context& context, const std::string& image_path, Options options = Options::None) const;
+    [[nodiscard]] Ptr<Texture> LoadImagesToTextureCube(Context& context, const CubeFaceResources& image_paths, Options options = Options::None) const;
 
 private:
     Data::Provider& m_data_provider;

--- a/Modules/Graphics/Extensions/Include/Methane/Graphics/MeshBuffers.hpp
+++ b/Modules/Graphics/Extensions/Include/Methane/Graphics/MeshBuffers.hpp
@@ -98,7 +98,7 @@ public:
     
     virtual ~MeshBuffers() = default;
 
-    RenderContext& GetRenderContext() const noexcept { return m_render_context; }
+    [[nodiscard]] RenderContext& GetRenderContext() const noexcept { return m_render_context; }
 
     void Draw(RenderCommandList& cmd_list, ProgramBindings& program_bindings,
               uint32_t mesh_subset_index = 0, uint32_t instance_count = 1, uint32_t start_instance = 0)
@@ -180,10 +180,11 @@ public:
         m_render_context.GetParallelExecutor().run(render_task_flow).get();
     }
 
-    const std::string&  GetMeshName() const      { return m_mesh_name; }
-    Data::Size          GetSubsetsCount() const  { return static_cast<Data::Size>(m_mesh_subsets.size()); }
-    Data::Size          GetInstanceCount() const { return static_cast<Data::Size>(m_final_pass_instance_uniforms.size()); }
+    [[nodiscard]] const std::string&  GetMeshName() const      { return m_mesh_name; }
+    [[nodiscard]] Data::Size          GetSubsetsCount() const  { return static_cast<Data::Size>(m_mesh_subsets.size()); }
+    [[nodiscard]] Data::Size          GetInstanceCount() const { return static_cast<Data::Size>(m_final_pass_instance_uniforms.size()); }
 
+    [[nodiscard]]
     const UniformsType& GetFinalPassUniforms(Data::Index instance_index = 0U) const
     {
         META_FUNCTION_TASK();
@@ -198,6 +199,7 @@ public:
         m_final_pass_instance_uniforms[instance_index] = std::move(uniforms);
     }
 
+    [[nodiscard]]
     Data::Size GetUniformsBufferSize() const
     {
         META_FUNCTION_TASK();
@@ -207,6 +209,7 @@ public:
         return Buffer::GetAlignedBufferSize(static_cast<Data::Size>(m_final_pass_instance_uniforms.size() * sizeof(m_final_pass_instance_uniforms[0])));
     }
 
+    [[nodiscard]]
     const Resource::SubResources& GetFinalPassUniformsSubresources() const { return m_final_pass_instance_uniforms_subresources; }
 
 protected:
@@ -220,26 +223,31 @@ protected:
         };
     }
 
+    [[nodiscard]]
     virtual Data::Index GetSubsetByInstanceIndex(Data::Index instance_index) const { return instance_index; }
 
+    [[nodiscard]]
     const BufferSet& GetVertexBuffers() const
     {
         META_CHECK_ARG_NOT_NULL(m_vertex_ptr);
         return *m_vertex_ptr;
     }
 
+    [[nodiscard]]
     BufferSet& GetVertexBuffers()
     {
         META_CHECK_ARG_NOT_NULL(m_vertex_ptr);
         return *m_vertex_ptr;
     }
 
+    [[nodiscard]]
     Buffer& GetIndexBuffer()
     {
         META_CHECK_ARG_NOT_NULL(m_index_ptr);
         return *m_index_ptr;
     }
-    
+
+    [[nodiscard]]
     Data::Size GetUniformsBufferOffset(uint32_t instance_index) const
     {
         META_FUNCTION_TASK();
@@ -281,12 +289,14 @@ public:
         m_subset_textures.resize(MeshBuffers<UniformsType>::GetSubsetsCount());
     }
 
+    [[nodiscard]]
     const Ptr<Texture>& GetTexturePtr() const
     {
         META_FUNCTION_TASK();
         return GetSubsetTexturePtr(0);
     }
 
+    [[nodiscard]]
     const Ptr<Texture>& GetSubsetTexturePtr(uint32_t subset_index) const
     {
         META_FUNCTION_TASK();
@@ -295,6 +305,7 @@ public:
         return m_subset_textures[subset_index];
     }
 
+    [[nodiscard]]
     const Ptr<Texture>& GetInstanceTexturePtr(uint32_t instance_index = 0) const
     {
         META_FUNCTION_TASK();

--- a/Modules/Graphics/Extensions/Include/Methane/Graphics/MeshBuffers.hpp
+++ b/Modules/Graphics/Extensions/Include/Methane/Graphics/MeshBuffers.hpp
@@ -252,8 +252,8 @@ protected:
     {
         META_FUNCTION_TASK();
         return static_cast<Data::Size>(
-            reinterpret_cast<const char*>(&m_final_pass_instance_uniforms[instance_index]) -
-            reinterpret_cast<const char*>(m_final_pass_instance_uniforms.data())
+            std::distance(reinterpret_cast<const std::byte*>(m_final_pass_instance_uniforms.data()),
+                          reinterpret_cast<const std::byte*>(&m_final_pass_instance_uniforms[instance_index]))
         );
     }
 

--- a/Modules/Graphics/Extensions/Include/Methane/Graphics/ScreenQuad.h
+++ b/Modules/Graphics/Extensions/Include/Methane/Graphics/ScreenQuad.h
@@ -67,9 +67,9 @@ public:
     void SetAlphaBlendingEnabled(bool alpha_blending_enabled);
     void SetTexture(Ptr<Texture> texture_ptr);
 
-    const Settings& GetQuadSettings() const noexcept { return m_settings; }
-    FrameRect       GetScreenRectInDots() const noexcept { return m_settings.screen_rect / m_context.GetContentScalingFactor(); }
-    const Texture&  GetTexture() const;
+    [[nodiscard]] const Settings& GetQuadSettings() const noexcept { return m_settings; }
+    [[nodiscard]] FrameRect       GetScreenRectInDots() const noexcept { return m_settings.screen_rect / m_context.GetContentScalingFactor(); }
+    [[nodiscard]] const Texture&  GetTexture() const;
 
     virtual void Draw(RenderCommandList& cmd_list, CommandList::DebugGroup* p_debug_group = nullptr) const;
 
@@ -79,7 +79,7 @@ protected:
 private:
     void UpdateConstantsBuffer() const;
 
-    static Shader::MacroDefinitions GetPixelShaderMacroDefinitions(TextureMode texture_mode);
+    [[nodiscard]] static Shader::MacroDefinitions GetPixelShaderMacroDefinitions(TextureMode texture_mode);
 
     Settings             m_settings;
     RenderContext&       m_context;

--- a/Modules/Graphics/Extensions/Include/Methane/Graphics/ScreenQuad.h
+++ b/Modules/Graphics/Extensions/Include/Methane/Graphics/ScreenQuad.h
@@ -74,7 +74,7 @@ public:
     virtual void Draw(RenderCommandList& cmd_list, CommandList::DebugGroup* p_debug_group = nullptr) const;
 
 protected:
-    RenderContext& GetRenderContext() noexcept { return m_context; }
+    [[nodiscard]] RenderContext& GetRenderContext() noexcept { return m_context; }
 
 private:
     void UpdateConstantsBuffer() const;

--- a/Modules/Graphics/Extensions/Sources/Methane/Graphics/ImageLoader.cpp
+++ b/Modules/Graphics/Extensions/Sources/Methane/Graphics/ImageLoader.cpp
@@ -205,11 +205,11 @@ Ptr<Texture> ImageLoader::LoadImagesToTextureCube(Context& context, const CubeFa
 
     Resource::SubResources face_resources;
     face_resources.reserve(face_images_data.size());
-    for(const std::pair<Data::Index, ImageData>& face_image_data : face_images_data)
+    for(const auto& [face_index, image_data] : face_images_data)
     {
-        META_CHECK_ARG_EQUAL_DESCR(face_dimensions,     face_image_data.second.GetDimensions(),    "all face image of cube texture must have equal dimensions");
-        META_CHECK_ARG_EQUAL_DESCR(face_channels_count, face_image_data.second.GetChannelsCount(), "all face image of cube texture must have equal channels count");
-        face_resources.emplace_back(face_image_data.second.GetPixels().GetDataPtr(), face_image_data.second.GetPixels().GetDataSize(), Resource::SubResource::Index(face_image_data.first));
+        META_CHECK_ARG_EQUAL_DESCR(face_dimensions,     image_data.GetDimensions(),    "all face image of cube texture must have equal dimensions");
+        META_CHECK_ARG_EQUAL_DESCR(face_channels_count, image_data.GetChannelsCount(), "all face image of cube texture must have equal channels count");
+        face_resources.emplace_back(image_data.GetPixels().GetDataPtr(), image_data.GetPixels().GetDataSize(), Resource::SubResource::Index(face_index));
     }
 
     // Load face images to cube texture

--- a/Modules/Graphics/Extensions/Sources/Methane/Graphics/ImageLoader.cpp
+++ b/Modules/Graphics/Extensions/Sources/Methane/Graphics/ImageLoader.cpp
@@ -48,6 +48,7 @@ by decoding them from popular image formats.
 namespace Methane::Graphics
 {
 
+[[nodiscard]]
 static PixelFormat GetDefaultImageFormat(bool srgb)
 {
     return srgb ? PixelFormat::RGBA8Unorm_sRGB : PixelFormat::RGBA8Unorm;
@@ -130,7 +131,7 @@ ImageLoader::ImageData ImageLoader::LoadImage(const std::string& image_path, siz
     int image_width = 0;
     int image_height = 0;
     int image_channels_count = 0;
-    stbi_uc* p_image_data = stbi_load_from_memory(reinterpret_cast<const stbi_uc *>(raw_image_data.GetDataPtr()),
+    stbi_uc* p_image_data = stbi_load_from_memory(reinterpret_cast<const stbi_uc *>(raw_image_data.GetDataPtr()), // NOSONAR
                                                   static_cast<int>(raw_image_data.GetDataSize()),
                                                   &image_width, &image_height, &image_channels_count,
                                                   static_cast<int>(channels_count));

--- a/Modules/Graphics/Extensions/Sources/Methane/Graphics/ImageLoader.cpp
+++ b/Modules/Graphics/Extensions/Sources/Methane/Graphics/ImageLoader.cpp
@@ -192,7 +192,7 @@ Ptr<Texture> ImageLoader::LoadImagesToTextureCube(Context& context, const CubeFa
             constexpr uint32_t desired_channels_count = 4;
             ImageLoader::ImageData image_data = LoadImage(image_paths[face_index], desired_channels_count, true);
 
-            std::lock_guard<LockableBase(std::mutex)> data_lock(data_mutex);
+            std::scoped_lock<LockableBase(std::mutex)> data_lock(data_mutex);
             face_images_data.emplace_back(face_index, std::move(image_data));
         }
     );

--- a/Modules/Graphics/Extensions/Sources/Methane/Graphics/ImageLoader.cpp
+++ b/Modules/Graphics/Extensions/Sources/Methane/Graphics/ImageLoader.cpp
@@ -130,7 +130,7 @@ ImageLoader::ImageData ImageLoader::LoadImage(const std::string& image_path, siz
     int image_width = 0;
     int image_height = 0;
     int image_channels_count = 0;
-    stbi_uc* p_image_data = stbi_load_from_memory(raw_image_data.GetDataPtr(),
+    stbi_uc* p_image_data = stbi_load_from_memory(reinterpret_cast<const stbi_uc *>(raw_image_data.GetDataPtr()),
                                                   static_cast<int>(raw_image_data.GetDataSize()),
                                                   &image_width, &image_height, &image_channels_count,
                                                   static_cast<int>(channels_count));
@@ -145,7 +145,8 @@ ImageLoader::ImageData ImageLoader::LoadImage(const std::string& image_path, siz
 
     if (create_copy)
     {
-        Data::Bytes image_data_copy(p_image_data, p_image_data + image_data_size);
+        Data::Bytes image_data_copy(reinterpret_cast<Data::ConstRawPtr>(p_image_data),
+                                    reinterpret_cast<Data::ConstRawPtr>(p_image_data + image_data_size));
         ImageData image_data(image_dimensions, static_cast<uint32_t>(image_channels_count), Data::Chunk(std::move(image_data_copy)));
         stbi_image_free(p_image_data);
         return image_data;

--- a/Modules/Graphics/Extensions/Sources/Methane/Graphics/ScreenQuad.cpp
+++ b/Modules/Graphics/Extensions/Sources/Methane/Graphics/ScreenQuad.cpp
@@ -199,8 +199,8 @@ ScreenQuad::ScreenQuad(RenderContext& context, const Ptr<Texture>& texture_ptr, 
 
     if (m_settings.texture_mode != TextureMode::Disabled)
     {
-        program_binding_resource_locations.emplace(Program::Argument(Shader::Type::Pixel, "g_texture"), Resource::Locations{ { m_texture_ptr         } });
-        program_binding_resource_locations.emplace(Program::Argument(Shader::Type::Pixel, "g_sampler"), Resource::Locations{ { m_texture_sampler_ptr } });
+        program_binding_resource_locations.try_emplace(Program::Argument(Shader::Type::Pixel, "g_texture"), Resource::Locations{ { m_texture_ptr         } });
+        program_binding_resource_locations.try_emplace(Program::Argument(Shader::Type::Pixel, "g_sampler"), Resource::Locations{ { m_texture_sampler_ptr } });
     }
 
     m_const_program_bindings_ptr = ProgramBindings::Create(m_render_state_ptr->GetSettings().program_ptr, program_binding_resource_locations);

--- a/Modules/Graphics/Extensions/Sources/Methane/Graphics/ScreenQuad.cpp
+++ b/Modules/Graphics/Extensions/Sources/Methane/Graphics/ScreenQuad.cpp
@@ -271,7 +271,7 @@ const Texture& ScreenQuad::GetTexture() const
 void ScreenQuad::Draw(RenderCommandList& cmd_list, CommandList::DebugGroup* p_debug_group) const
 {
     META_FUNCTION_TASK();
-    cmd_list.ResetWithState(m_render_state_ptr, p_debug_group);
+    cmd_list.ResetOnceWithState(m_render_state_ptr, p_debug_group);
     cmd_list.SetViewState(*m_view_state_ptr);
     cmd_list.SetProgramBindings(*m_const_program_bindings_ptr);
     cmd_list.SetVertexBuffers(*m_vertex_buffer_set_ptr);

--- a/Modules/Graphics/Extensions/Sources/Methane/Graphics/ScreenQuad.cpp
+++ b/Modules/Graphics/Extensions/Sources/Methane/Graphics/ScreenQuad.cpp
@@ -271,7 +271,7 @@ const Texture& ScreenQuad::GetTexture() const
 void ScreenQuad::Draw(RenderCommandList& cmd_list, CommandList::DebugGroup* p_debug_group) const
 {
     META_FUNCTION_TASK();
-    cmd_list.ResetOnceWithState(m_render_state_ptr, p_debug_group);
+    cmd_list.ResetOnceWithState(*m_render_state_ptr, p_debug_group);
     cmd_list.SetViewState(*m_view_state_ptr);
     cmd_list.SetProgramBindings(*m_const_program_bindings_ptr);
     cmd_list.SetVertexBuffers(*m_vertex_buffer_set_ptr);

--- a/Modules/Graphics/Extensions/Sources/Methane/Graphics/ScreenQuad.cpp
+++ b/Modules/Graphics/Extensions/Sources/Methane/Graphics/ScreenQuad.cpp
@@ -271,7 +271,7 @@ const Texture& ScreenQuad::GetTexture() const
 void ScreenQuad::Draw(RenderCommandList& cmd_list, CommandList::DebugGroup* p_debug_group) const
 {
     META_FUNCTION_TASK();
-    cmd_list.ResetOnceWithState(*m_render_state_ptr, p_debug_group);
+    cmd_list.ResetWithStateOnce(*m_render_state_ptr, p_debug_group);
     cmd_list.SetViewState(*m_view_state_ptr);
     cmd_list.SetProgramBindings(*m_const_program_bindings_ptr);
     cmd_list.SetVertexBuffers(*m_vertex_buffer_set_ptr);

--- a/Modules/Graphics/Extensions/Sources/Methane/Graphics/SkyBox.cpp
+++ b/Modules/Graphics/Extensions/Sources/Methane/Graphics/SkyBox.cpp
@@ -132,7 +132,7 @@ void SkyBox::Draw(RenderCommandList& cmd_list, MeshBufferBindings& buffer_bindin
     META_CHECK_ARG_GREATER_OR_EQUAL(buffer_bindings.uniforms_buffer_ptr->GetDataSize(), sizeof(Uniforms));
     buffer_bindings.uniforms_buffer_ptr->SetData(m_mesh_buffers.GetFinalPassUniformsSubresources());
 
-    cmd_list.ResetWithState(m_render_state_ptr, s_debug_group.get());
+    cmd_list.ResetOnceWithState(m_render_state_ptr, s_debug_group.get());
     cmd_list.SetViewState(view_state);
     
     META_CHECK_ARG_NOT_EMPTY(buffer_bindings.program_bindings_per_instance);

--- a/Modules/Graphics/Extensions/Sources/Methane/Graphics/SkyBox.cpp
+++ b/Modules/Graphics/Extensions/Sources/Methane/Graphics/SkyBox.cpp
@@ -132,7 +132,7 @@ void SkyBox::Draw(RenderCommandList& cmd_list, MeshBufferBindings& buffer_bindin
     META_CHECK_ARG_GREATER_OR_EQUAL(buffer_bindings.uniforms_buffer_ptr->GetDataSize(), sizeof(Uniforms));
     buffer_bindings.uniforms_buffer_ptr->SetData(m_mesh_buffers.GetFinalPassUniformsSubresources());
 
-    cmd_list.ResetOnceWithState(m_render_state_ptr, s_debug_group.get());
+    cmd_list.ResetOnceWithState(*m_render_state_ptr, s_debug_group.get());
     cmd_list.SetViewState(view_state);
     
     META_CHECK_ARG_NOT_EMPTY(buffer_bindings.program_bindings_per_instance);

--- a/Modules/Graphics/Extensions/Sources/Methane/Graphics/SkyBox.cpp
+++ b/Modules/Graphics/Extensions/Sources/Methane/Graphics/SkyBox.cpp
@@ -132,7 +132,7 @@ void SkyBox::Draw(RenderCommandList& cmd_list, MeshBufferBindings& buffer_bindin
     META_CHECK_ARG_GREATER_OR_EQUAL(buffer_bindings.uniforms_buffer_ptr->GetDataSize(), sizeof(Uniforms));
     buffer_bindings.uniforms_buffer_ptr->SetData(m_mesh_buffers.GetFinalPassUniformsSubresources());
 
-    cmd_list.ResetOnceWithState(*m_render_state_ptr, s_debug_group.get());
+    cmd_list.ResetWithStateOnce(*m_render_state_ptr, s_debug_group.get());
     cmd_list.SetViewState(view_state);
     
     META_CHECK_ARG_NOT_EMPTY(buffer_bindings.program_bindings_per_instance);

--- a/Modules/Graphics/Primitives/Include/Methane/Graphics/FpsCounter.h
+++ b/Modules/Graphics/Primitives/Include/Methane/Graphics/FpsCounter.h
@@ -41,17 +41,17 @@ public:
         FrameTiming(const FrameTiming&) noexcept = default;
         FrameTiming(double total_time_sec, double present_time_sec, double gpu_wait_time_sec) noexcept;
 
-        double GetTotalTimeSec() const noexcept   { return m_total_time_sec; }
-        double GetPresentTimeSec() const noexcept { return m_present_time_sec; }
-        double GetGpuWaitTimeSec() const noexcept { return m_gpu_wait_time_sec; }
-        double GetCpuTimeSec() const noexcept     { return m_total_time_sec - m_present_time_sec - m_gpu_wait_time_sec; }
+        [[nodiscard]] double GetTotalTimeSec() const noexcept   { return m_total_time_sec; }
+        [[nodiscard]] double GetPresentTimeSec() const noexcept { return m_present_time_sec; }
+        [[nodiscard]] double GetGpuWaitTimeSec() const noexcept { return m_gpu_wait_time_sec; }
+        [[nodiscard]] double GetCpuTimeSec() const noexcept     { return m_total_time_sec - m_present_time_sec - m_gpu_wait_time_sec; }
 
-        double GetTotalTimeMSec() const noexcept  { return m_total_time_sec * 1000.0; }
-        double GetPresentTimeMSec() const noexcept{ return m_present_time_sec * 1000.0; }
-        double GetGpuWaitTimeMSec() const noexcept{ return m_gpu_wait_time_sec * 1000.0; }
-        double GetCpuTimeMSec() const noexcept    { return GetCpuTimeSec() * 1000.0; }
+        [[nodiscard]] double GetTotalTimeMSec() const noexcept  { return m_total_time_sec * 1000.0; }
+        [[nodiscard]] double GetPresentTimeMSec() const noexcept{ return m_present_time_sec * 1000.0; }
+        [[nodiscard]] double GetGpuWaitTimeMSec() const noexcept{ return m_gpu_wait_time_sec * 1000.0; }
+        [[nodiscard]] double GetCpuTimeMSec() const noexcept    { return GetCpuTimeSec() * 1000.0; }
 
-        double GetCpuTimePercent() const noexcept { return 100.0 * GetCpuTimeSec() / GetTotalTimeSec(); }
+        [[nodiscard]] double GetCpuTimePercent() const noexcept { return 100.0 * GetCpuTimeSec() / GetTotalTimeSec(); }
 
         FrameTiming& operator=(const FrameTiming& other) noexcept = default;
         FrameTiming& operator+=(const FrameTiming& other) noexcept;
@@ -74,9 +74,9 @@ public:
     void OnGpuFramePresented() noexcept      { m_present_on_gpu_wait_time_sec = m_present_timer.GetElapsedSecondsD(); }
     void OnCpuFramePresented() noexcept;
 
-    uint32_t    GetAveragedTimingsCount() const noexcept { return static_cast<uint32_t>(m_frame_timings.size()); }
-    FrameTiming GetAverageFrameTiming() const noexcept;
-    uint32_t    GetFramesPerSecond() const noexcept;
+    [[nodiscard]] uint32_t    GetAveragedTimingsCount() const noexcept { return static_cast<uint32_t>(m_frame_timings.size()); }
+    [[nodiscard]] FrameTiming GetAverageFrameTiming() const noexcept;
+    [[nodiscard]] uint32_t    GetFramesPerSecond() const noexcept;
 
 private:
     void ResetPresentTimer() noexcept;

--- a/Modules/Graphics/Primitives/Include/Methane/Graphics/Mesh.h
+++ b/Modules/Graphics/Primitives/Include/Methane/Graphics/Mesh.h
@@ -92,7 +92,7 @@ public:
         public:
             explicit IncompatibleException(VertexField missing_field);
 
-            VertexField GetMissingField() const noexcept { return m_missing_field; }
+            [[nodiscard]] VertexField GetMissingField() const noexcept { return m_missing_field; }
 
         private:
             const VertexField m_missing_field;
@@ -100,20 +100,20 @@ public:
 
         using std::vector<VertexField>::vector;
 
-        std::vector<std::string> GetSemantics() const;
+        [[nodiscard]] std::vector<std::string> GetSemantics() const;
 
-        static std::string GetSemanticByVertexField(VertexField vertex_field);
+        [[nodiscard]] static std::string GetSemanticByVertexField(VertexField vertex_field);
     };
 
     Mesh(Type type, const VertexLayout& vertex_layout);
 
-    Type                GetType() const noexcept               { return m_type; }
-    const VertexLayout& GetVertexLayout() const noexcept       { return m_vertex_layout; }
-    Data::Size          GetVertexSize() const noexcept         { return m_vertex_size; }
-    const Indices&      GetIndices() const noexcept            { return m_indices; }
-    Index               GetIndex(Data::Index i) const noexcept { return i < m_indices.size() ? m_indices[i] : 0; }
-    Data::Size          GetIndexCount() const noexcept         { return static_cast<Data::Size>(m_indices.size()); }
-    Data::Size          GetIndexDataSize() const noexcept      { return static_cast<Data::Size>(m_indices.size() * sizeof(Index)); }
+    [[nodiscard]] Type                GetType() const noexcept               { return m_type; }
+    [[nodiscard]] const VertexLayout& GetVertexLayout() const noexcept       { return m_vertex_layout; }
+    [[nodiscard]] Data::Size          GetVertexSize() const noexcept         { return m_vertex_size; }
+    [[nodiscard]] const Indices&      GetIndices() const noexcept            { return m_indices; }
+    [[nodiscard]] Index               GetIndex(Data::Index i) const noexcept { return i < m_indices.size() ? m_indices[i] : 0; }
+    [[nodiscard]] Data::Size          GetIndexCount() const noexcept         { return static_cast<Data::Size>(m_indices.size()); }
+    [[nodiscard]] Data::Size          GetIndexDataSize() const noexcept      { return static_cast<Data::Size>(m_indices.size() * sizeof(Index)); }
 
 protected:
     struct Edge
@@ -122,15 +122,15 @@ protected:
         const Mesh::Index second_index;
         
         Edge(Mesh::Index v1_index, Mesh::Index v2_index);
-        
-        bool operator<(const Edge& other) const;
+
+        [[nodiscard]] bool operator<(const Edge& other) const;
     };
     
     using VertexFieldOffsets = std::array<int32_t, magic_enum::enum_count<VertexField>()>;
 
-    bool HasVertexField(VertexField field) const noexcept;
     void CheckLayoutHasVertexField(VertexField field) const;
-    int32_t GetVertexFieldOffset(VertexField field) const { return m_vertex_field_offsets[static_cast<size_t>(field)]; }
+    [[nodiscard]] bool HasVertexField(VertexField field) const noexcept;
+    [[nodiscard]] int32_t GetVertexFieldOffset(VertexField field) const { return m_vertex_field_offsets[static_cast<size_t>(field)]; }
 
     void ResizeIndices(size_t indices_count)         { m_indices.resize(indices_count, 0); }
     void SetIndex(size_t index, Index vertex_index)  { m_indices[index] = vertex_index; }
@@ -139,24 +139,24 @@ protected:
     void AppendIndices(const Mesh::Indices& indices) { m_indices.insert(m_indices.end(), indices.begin(), indices.end()); }
     auto GetIndicesBackInserter()                    { return std::back_inserter(m_indices); }
 
-    static VertexFieldOffsets GetVertexFieldOffsets(const VertexLayout& vertex_layout);
-    static Data::Size         GetVertexSize(const VertexLayout& vertex_layout) noexcept;
-    static Data::Size         GetVertexFieldSize(VertexField vertex_field)   { return GetVertexFieldSize(static_cast<size_t>(vertex_field)); }
-    static Data::Size         GetVertexFieldSize(size_t vertex_field_index);
-    static const Position2D&  GetFacePosition2D(size_t index);
-    static Data::Size         GetFacePositionCount() noexcept;
-    static const TexCoord&    GetFaceTexCoord(size_t index);
-    static Mesh::Index        GetFaceIndex(size_t index);
-    static Data::Size         GetFaceIndicesCount() noexcept;
-    static const Color&       GetColor(size_t index);
-    static Data::Size         GetColorsCount() noexcept;
+    [[nodiscard]] static VertexFieldOffsets GetVertexFieldOffsets(const VertexLayout& vertex_layout);
+    [[nodiscard]] static Data::Size         GetVertexSize(const VertexLayout& vertex_layout) noexcept;
+    [[nodiscard]] static Data::Size         GetVertexFieldSize(VertexField vertex_field)   { return GetVertexFieldSize(static_cast<size_t>(vertex_field)); }
+    [[nodiscard]] static Data::Size         GetVertexFieldSize(size_t vertex_field_index);
+    [[nodiscard]] static const Position2D&  GetFacePosition2D(size_t index);
+    [[nodiscard]] static Data::Size         GetFacePositionCount() noexcept;
+    [[nodiscard]] static const TexCoord&    GetFaceTexCoord(size_t index);
+    [[nodiscard]] static Mesh::Index        GetFaceIndex(size_t index);
+    [[nodiscard]] static Data::Size         GetFaceIndicesCount() noexcept;
+    [[nodiscard]] static const Color&       GetColor(size_t index);
+    [[nodiscard]] static Data::Size         GetColorsCount() noexcept;
 
 private:
-    const Type                  m_type;
-    const VertexLayout          m_vertex_layout;
-    const VertexFieldOffsets    m_vertex_field_offsets;
-    const Data::Size            m_vertex_size;
-    Indices                     m_indices;
+    const Type               m_type;
+    const VertexLayout       m_vertex_layout;
+    const VertexFieldOffsets m_vertex_field_offsets;
+    const Data::Size         m_vertex_size;
+    Indices                  m_indices;
 };
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Primitives/Include/Methane/Graphics/Mesh/BaseMesh.hpp
+++ b/Modules/Graphics/Primitives/Include/Methane/Graphics/Mesh/BaseMesh.hpp
@@ -73,8 +73,8 @@ protected:
     Index AddEdgeMidpoint(const Edge& edge, EdgeMidpoints& edge_midpoints)
     {
         META_FUNCTION_TASK();
-        const auto edge_midpoint_it = edge_midpoints.find(edge);
-        if (edge_midpoint_it != edge_midpoints.end())
+        if (const auto edge_midpoint_it = edge_midpoints.find(edge);
+            edge_midpoint_it != edge_midpoints.end())
             return edge_midpoint_it->second;
 
         const VType& v1 = m_vertices[edge.first_index];

--- a/Modules/Graphics/Primitives/Include/Methane/Graphics/Mesh/BaseMesh.hpp
+++ b/Modules/Graphics/Primitives/Include/Methane/Graphics/Mesh/BaseMesh.hpp
@@ -111,7 +111,7 @@ protected:
         }
 
         const auto v_mid_index = static_cast<Mesh::Index>(m_vertices.size());
-        edge_midpoints.emplace(edge, v_mid_index);
+        edge_midpoints.try_emplace(edge, v_mid_index);
         m_vertices.push_back(v_mid);
         return v_mid_index;
     }

--- a/Modules/Graphics/Primitives/Include/Methane/Graphics/Mesh/BaseMesh.hpp
+++ b/Modules/Graphics/Primitives/Include/Methane/Graphics/Mesh/BaseMesh.hpp
@@ -46,27 +46,27 @@ public:
         META_CHECK_ARG_EQUAL_DESCR(GetVertexSize(), sizeof(VType), "size of vertex structure differs from vertex size calculated by vertex layout");
     }
 
-    const Vertices& GetVertices() const noexcept       { return m_vertices; }
-    Data::Size      GetVertexCount() const noexcept    { return static_cast<Data::Size>(m_vertices.size()); }
-    Data::Size      GetVertexDataSize() const noexcept { return static_cast<Data::Size>(m_vertices.size() * GetVertexSize()); }
+    [[nodiscard]] const Vertices& GetVertices() const noexcept       { return m_vertices; }
+    [[nodiscard]] Data::Size      GetVertexCount() const noexcept    { return static_cast<Data::Size>(m_vertices.size()); }
+    [[nodiscard]] Data::Size      GetVertexDataSize() const noexcept { return static_cast<Data::Size>(m_vertices.size() * GetVertexSize()); }
 
 protected:
     template<typename FType>
-    FType& GetVertexField(VType& vertex, VertexField field) noexcept
+    [[nodiscard]] FType& GetVertexField(VType& vertex, VertexField field) noexcept
     {
         META_FUNCTION_TASK();
         const int32_t field_offset = GetVertexFieldOffset(field);
         assert(field_offset >= 0);
-        return *reinterpret_cast<FType*>(reinterpret_cast<char*>(&vertex) + field_offset);
+        return *reinterpret_cast<FType*>(reinterpret_cast<std::byte*>(&vertex) + field_offset);
     }
 
     template<typename FType>
-    const FType& GetVertexField(const VType& vertex, VertexField field) noexcept
+    [[nodiscard]] const FType& GetVertexField(const VType& vertex, VertexField field) noexcept
     {
         META_FUNCTION_TASK();
         const int32_t field_offset = GetVertexFieldOffset(field);
         assert(field_offset >= 0);
-        return *reinterpret_cast<const FType*>(reinterpret_cast<const char*>(&vertex) + field_offset);
+        return *reinterpret_cast<const FType*>(reinterpret_cast<const std::byte*>(&vertex) + field_offset);
     }
 
     using EdgeMidpoints = std::map<Mesh::Edge, Mesh::Index>;

--- a/Modules/Graphics/Primitives/Include/Methane/Graphics/PerlinNoise.h
+++ b/Modules/Graphics/Primitives/Include/Methane/Graphics/PerlinNoise.h
@@ -33,17 +33,17 @@ namespace Methane::Graphics
 class PerlinNoise
 {
 public:
-    PerlinNoise(float persistence = 0.5F, size_t octaves_count = 4);
+    explicit PerlinNoise(float persistence = 0.5F, size_t octaves_count = 4);
     
-    float operator()(Vector2f pos) const;
-    float operator()(Vector3f pos) const;
-    float operator()(Vector4f pos) const;
+    [[nodiscard]] float operator()(Vector2f pos) const;
+    [[nodiscard]] float operator()(Vector3f pos) const;
+    [[nodiscard]] float operator()(Vector4f pos) const;
 
 private:
     using Weights = std::vector<float>;
 
-    static Weights GetWeights(float persistence, size_t octaves_count);
-    static float GetWeightsSum(const PerlinNoise::Weights& weights);
+    [[nodiscard]] static Weights GetWeights(float persistence, size_t octaves_count);
+    [[nodiscard]] static float GetWeightsSum(const PerlinNoise::Weights& weights);
 
     const Weights m_weights;
     const float   m_norm_multiplier;

--- a/Modules/Graphics/Primitives/Include/Methane/Graphics/Windows/ErrorHandling.h
+++ b/Modules/Graphics/Primitives/Include/Methane/Graphics/Windows/ErrorHandling.h
@@ -41,8 +41,8 @@ public:
     RuntimeException(HRESULT hr, ID3D12Device* device = nullptr);
     RuntimeException(HRESULT hr, const wrl::ComPtr<ID3DBlob>& error_blob);
 
-    HRESULT             GetResult() const noexcept { return m_result; }
-    const ID3D12Device* GetDevice() const noexcept { return m_device; }
+    [[nodiscard]] HRESULT             GetResult() const noexcept { return m_result; }
+    [[nodiscard]] const ID3D12Device* GetDevice() const noexcept { return m_device; }
 
 private:
     const HRESULT       m_result;

--- a/Modules/Graphics/Types/Include/Methane/Graphics/Color.hpp
+++ b/Modules/Graphics/Types/Include/Methane/Graphics/Color.hpp
@@ -53,12 +53,12 @@ public:
 
     explicit ColorF(VectorType&& components) noexcept : m_components(std::move(components)) { }
 
-    bool operator==(const ColorF& other) const noexcept  { return m_components == other.m_components; }
-    bool operator!=(const ColorF& other) const noexcept  { return m_components != other.m_components; }
-    float operator[](Data::Index component_index) const  { META_CHECK_ARG_LESS(component_index, Size); return m_components[static_cast<int>(component_index)]; }
-    explicit operator VectorType() const noexcept { return m_components; }
+    [[nodiscard]] bool operator==(const ColorF& other) const noexcept  { return m_components == other.m_components; }
+    [[nodiscard]] bool operator!=(const ColorF& other) const noexcept  { return m_components != other.m_components; }
+    [[nodiscard]] float operator[](Data::Index component_index) const  { META_CHECK_ARG_LESS(component_index, Size); return m_components[static_cast<int>(component_index)]; }
+    [[nodiscard]] explicit operator VectorType() const noexcept { return m_components; }
 
-    const VectorType& AsVector() const noexcept { return m_components; }
+    [[nodiscard]] const VectorType& AsVector() const noexcept { return m_components; }
 
     [[nodiscard]] Data::Size GetSize() const noexcept      { return vector_size; }
 
@@ -96,7 +96,7 @@ public:
     template<size_t sz = vector_size, typename = std::enable_if_t<sz >= 4, void>>
     void SetA(float a) { Set(3, a); }
 
-    explicit operator std::string() const noexcept
+    [[nodiscard]] explicit operator std::string() const noexcept
     {
         if constexpr (vector_size == 3)
             return fmt::format("C(r:{:d}, g:{:d}, b:{:d})", GetRu(), GetGu(), GetBu());

--- a/Modules/Graphics/Types/Include/Methane/Graphics/Color.hpp
+++ b/Modules/Graphics/Types/Include/Methane/Graphics/Color.hpp
@@ -60,28 +60,28 @@ public:
 
     const VectorType& AsVector() const noexcept { return m_components; }
 
-    Data::Size GetSize() const noexcept      { return vector_size; }
+    [[nodiscard]] Data::Size GetSize() const noexcept      { return vector_size; }
 
-    float GetRf() const noexcept { return m_components[0]; }
-    float GetGf() const noexcept { return m_components[1]; }
-    float GetBf() const noexcept { return m_components[2]; }
+    [[nodiscard]] float GetRf() const noexcept { return m_components[0]; }
+    [[nodiscard]] float GetGf() const noexcept { return m_components[1]; }
+    [[nodiscard]] float GetBf() const noexcept { return m_components[2]; }
 
     template<size_t sz = vector_size, typename = std::enable_if_t<sz>= 4, void>>
-    float GetAf() const noexcept { return m_components[3]; }
+    [[nodiscard]] float GetAf() const noexcept { return m_components[3]; }
 
-    float GetNormRf() const noexcept { return GetNormColorComponent(GetRf()); }
-    float GetNormGf() const noexcept { return GetNormColorComponent(GetGf()); }
-    float GetNormBf() const noexcept { return GetNormColorComponent(GetBf()); }
-
-    template<size_t sz = vector_size, typename = std::enable_if_t<sz >= 4, void>>
-    float GetNormAf() const noexcept { return GetNormColorComponent(GetAf()); }
-
-    uint8_t GetRu() const noexcept { return GetUintColorComponent(GetNormRf()); }
-    uint8_t GetGu() const noexcept { return GetUintColorComponent(GetNormGf()); }
-    uint8_t GetBu() const noexcept { return GetUintColorComponent(GetNormBf()); }
+    [[nodiscard]] float GetNormRf() const noexcept { return GetNormColorComponent(GetRf()); }
+    [[nodiscard]] float GetNormGf() const noexcept { return GetNormColorComponent(GetGf()); }
+    [[nodiscard]] float GetNormBf() const noexcept { return GetNormColorComponent(GetBf()); }
 
     template<size_t sz = vector_size, typename = std::enable_if_t<sz >= 4, void>>
-    uint8_t GetAu() const noexcept { return GetUintColorComponent(GetNormAf()); }
+    [[nodiscard]] float GetNormAf() const noexcept { return GetNormColorComponent(GetAf()); }
+
+    [[nodiscard]] uint8_t GetRu() const noexcept { return GetUintColorComponent(GetNormRf()); }
+    [[nodiscard]] uint8_t GetGu() const noexcept { return GetUintColorComponent(GetNormGf()); }
+    [[nodiscard]] uint8_t GetBu() const noexcept { return GetUintColorComponent(GetNormBf()); }
+
+    template<size_t sz = vector_size, typename = std::enable_if_t<sz >= 4, void>>
+    [[nodiscard]] uint8_t GetAu() const noexcept { return GetUintColorComponent(GetNormAf()); }
 
     void Set(Data::Index component_index, float value)
     {
@@ -105,12 +105,12 @@ public:
     }
 
 private:
-    inline float GetNormColorComponent(float component) const noexcept
+    [[nodiscard]] inline float GetNormColorComponent(float component) const noexcept
     {
         return std::max(s_float_range.first, std::min(s_float_range.second, component));
     }
 
-    inline uint8_t GetUintColorComponent(float component) const noexcept
+    [[nodiscard]] inline uint8_t GetUintColorComponent(float component) const noexcept
     {
         return static_cast<uint8_t>(std::round(component * static_cast<float>(s_uint_component_max)));
     }

--- a/Modules/Graphics/Types/Include/Methane/Graphics/Rect.hpp
+++ b/Modules/Graphics/Types/Include/Methane/Graphics/Rect.hpp
@@ -42,7 +42,7 @@ using FloatPoint   = Data::FloatPoint;
 using ScissorRect  = Rect<uint32_t, uint32_t>;
 using ScissorRects = std::vector<ScissorRect>;
 
-ScissorRect GetFrameScissorRect(const FrameRect& frame_rect, const FrameSize& render_attachment_size = FrameSize::Max());
-ScissorRect GetFrameScissorRect(const FrameSize& frame_size);
+[[nodiscard]] ScissorRect GetFrameScissorRect(const FrameRect& frame_rect, const FrameSize& render_attachment_size = FrameSize::Max());
+[[nodiscard]] ScissorRect GetFrameScissorRect(const FrameSize& frame_size);
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Types/Include/Methane/Graphics/TypeConverters.hpp
+++ b/Modules/Graphics/Types/Include/Methane/Graphics/TypeConverters.hpp
@@ -29,18 +29,18 @@ namespace Methane::Graphics
 {
 
 template<typename TIndex>
-PixelFormat GetIndexFormat(TIndex) noexcept          { return PixelFormat::Unknown; }
+[[nodiscard]] PixelFormat GetIndexFormat(TIndex) noexcept          { return PixelFormat::Unknown; }
 
 template<>
-inline PixelFormat GetIndexFormat(uint32_t) noexcept { return PixelFormat::R32Uint; }
+[[nodiscard]] inline PixelFormat GetIndexFormat(uint32_t) noexcept { return PixelFormat::R32Uint; }
 
 template<>
-inline PixelFormat GetIndexFormat(int32_t) noexcept  { return PixelFormat::R32Sint; }
+[[nodiscard]] inline PixelFormat GetIndexFormat(int32_t) noexcept  { return PixelFormat::R32Sint; }
 
 template<>
-inline PixelFormat GetIndexFormat(uint16_t) noexcept { return PixelFormat::R16Uint; }
+[[nodiscard]] inline PixelFormat GetIndexFormat(uint16_t) noexcept { return PixelFormat::R16Uint; }
 
 template<>
-inline PixelFormat GetIndexFormat(int16_t) noexcept  { return PixelFormat::R16Sint; }
+[[nodiscard]] inline PixelFormat GetIndexFormat(int16_t) noexcept  { return PixelFormat::R16Sint; }
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Types/Include/Methane/Graphics/TypeFormatters.hpp
+++ b/Modules/Graphics/Types/Include/Methane/Graphics/TypeFormatters.hpp
@@ -35,7 +35,7 @@ template<typename T>
 struct fmt::formatter<cml::vector<T, cml::fixed<2>>>
 {
     template<typename FormatContext>
-    auto format(const cml::vector<T, cml::fixed<2>>& v, FormatContext& ctx) { return format_to(ctx.out(), "V({}, {})", v[0], v[1]); }
+    [[nodiscard]] auto format(const cml::vector<T, cml::fixed<2>>& v, FormatContext& ctx) { return format_to(ctx.out(), "V({}, {})", v[0], v[1]); }
     constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
 };
 
@@ -43,7 +43,7 @@ template<typename T>
 struct fmt::formatter<cml::vector<T, cml::fixed<3>>>
 {
     template<typename FormatContext>
-    auto format(const cml::vector<T, cml::fixed<3>>& v, FormatContext& ctx) { return format_to(ctx.out(), "V({}, {}, {})", v[0], v[1], v[2]); }
+    [[nodiscard]] auto format(const cml::vector<T, cml::fixed<3>>& v, FormatContext& ctx) { return format_to(ctx.out(), "V({}, {}, {})", v[0], v[1], v[2]); }
     constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
 };
 
@@ -51,7 +51,7 @@ template<typename T>
 struct fmt::formatter<cml::vector<T, cml::fixed<4>>>
 {
     template<typename FormatContext>
-    auto format(const cml::vector<T, cml::fixed<4>>& v, FormatContext& ctx) { return format_to(ctx.out(), "V({}, {}, {}, {})", v[0], v[1], v[3], v[3]); }
+    [[nodiscard]] auto format(const cml::vector<T, cml::fixed<4>>& v, FormatContext& ctx) { return format_to(ctx.out(), "V({}, {}, {}, {})", v[0], v[1], v[3], v[3]); }
     constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
 };
 
@@ -59,7 +59,7 @@ template<typename D>
 struct fmt::formatter<Methane::Graphics::VolumeSize<D>>
 {
     template<typename FormatContext>
-    auto format(const Methane::Graphics::VolumeSize<D>& vol_size, FormatContext& ctx) { return format_to(ctx.out(), "{}", static_cast<std::string>(vol_size)); }
+    [[nodiscard]] auto format(const Methane::Graphics::VolumeSize<D>& vol_size, FormatContext& ctx) { return format_to(ctx.out(), "{}", static_cast<std::string>(vol_size)); }
     constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
 };
 
@@ -67,7 +67,7 @@ template<typename T, typename D>
 struct fmt::formatter<Methane::Graphics::Volume<T, D>>
 {
     template<typename FormatContext>
-    auto format(const Methane::Graphics::Volume<T, D>& vol, FormatContext& ctx) { return format_to(ctx.out(), "{}", static_cast<std::string>(vol)); }
+    [[nodiscard]] auto format(const Methane::Graphics::Volume<T, D>& vol, FormatContext& ctx) { return format_to(ctx.out(), "{}", static_cast<std::string>(vol)); }
     constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
 };
 
@@ -75,6 +75,6 @@ template<size_t color_size>
 struct fmt::formatter<Methane::Graphics::ColorF<color_size>>
 {
     template<typename FormatContext>
-    auto format(const Methane::Graphics::ColorF<color_size>& color, FormatContext& ctx) { return format_to(ctx.out(), "{}", static_cast<std::string>(color)); }
+    [[nodiscard]] auto format(const Methane::Graphics::ColorF<color_size>& color, FormatContext& ctx) { return format_to(ctx.out(), "{}", static_cast<std::string>(color)); }
     constexpr auto parse(const format_parse_context& ctx) const { return ctx.end(); }
 };

--- a/Modules/Graphics/Types/Include/Methane/Graphics/Types.h
+++ b/Modules/Graphics/Types/Include/Methane/Graphics/Types.h
@@ -91,8 +91,8 @@ enum class PixelFormat : uint32_t
 
 using PixelFormats = std::vector<PixelFormat>;
 
-Data::Size GetPixelSize(PixelFormat pixel_format);
-bool IsSrgbColorSpace(PixelFormat pixel_format) noexcept;
+[[nodiscard]] Data::Size GetPixelSize(PixelFormat pixel_format);
+[[nodiscard]] bool IsSrgbColorSpace(PixelFormat pixel_format) noexcept;
 
 enum class Compare : uint32_t
 {

--- a/Modules/Graphics/Types/Include/Methane/Graphics/Volume.hpp
+++ b/Modules/Graphics/Types/Include/Methane/Graphics/Volume.hpp
@@ -156,7 +156,7 @@ using Dimensions = VolumeSize<uint32_t>;
 using Viewport  = Volume<double, double>;
 using Viewports = std::vector<Viewport>;
 
-Viewport GetFrameViewport(const FrameSize& frame_size);
-Viewport GetFrameViewport(const FrameRect& frame_rect);
+[[nodiscard]] Viewport GetFrameViewport(const FrameSize& frame_size);
+[[nodiscard]] Viewport GetFrameViewport(const FrameRect& frame_rect);
 
 } // namespace Methane::Graphics

--- a/Modules/Graphics/Types/Sources/Methane/Graphics/Types.cpp
+++ b/Modules/Graphics/Types/Sources/Methane/Graphics/Types.cpp
@@ -31,6 +31,7 @@ Methane graphics type functions implementation.
 namespace Methane::Graphics
 {
 
+[[nodiscard]]
 inline uint32_t GetNormalizedDimensionSize(int32_t offset, uint32_t dimension_size, uint32_t render_attachment_size)
 {
     return std::min(dimension_size + offset, render_attachment_size) - (offset >= 0 ? offset : 0);

--- a/Modules/Platform/App/Include/Methane/Platform/AppBase.h
+++ b/Modules/Platform/App/Include/Methane/Platform/AppBase.h
@@ -36,7 +36,7 @@ Base application interface and platform-independent implementation.
 #include <vector>
 #include <memory>
 
-namespace tf
+namespace tf // NOSONAR
 {
 // TaskFlow Executor class forward declaration:
 // #include <taskflow/core/executor.hpp>

--- a/Modules/Platform/App/Sources/Methane/Platform/AppBase.cpp
+++ b/Modules/Platform/App/Sources/Methane/Platform/AppBase.cpp
@@ -35,6 +35,7 @@ Base application interface and platform-independent implementation.
 
 #include <sstream>
 #include <vector>
+#include <string_view>
 #include <cstdlib>
 
 namespace Methane::Platform
@@ -57,7 +58,7 @@ static bool WriteControllerHeaderToHelpStream(std::stringstream& help_stream, co
     return false;
 }
 
-static void WriteKeyDescriptionToHelpStream(std::stringstream& help_stream, const std::string& single_offset, const std::string& controller_offset,
+static void WriteKeyDescriptionToHelpStream(std::stringstream& help_stream, std::string_view single_offset, std::string_view controller_offset,
                                             bool first_line, bool& header_present, const Input::IHelpProvider::KeyDescription& key_description)
 {
     if (key_description.first.empty())

--- a/Modules/Platform/App/Sources/Methane/Platform/Windows/AppWin.cpp
+++ b/Modules/Platform/App/Sources/Methane/Platform/Windows/AppWin.cpp
@@ -58,9 +58,8 @@ AppWin::AppWin(const AppBase::Settings& settings)
 int AppWin::Run(const RunArgs& args)
 {
     // Skip instrumentation META_FUNCTION_TASK() since this is the only root function running till application close
-
-    const int base_return_code = AppBase::Run(args);
-    if (base_return_code)
+    if (const int base_return_code = AppBase::Run(args);
+        base_return_code)
         return base_return_code;
 
     // Initialize the window class.
@@ -493,13 +492,12 @@ bool AppWin::SetFullScreen(bool is_full_screen)
 
     META_CHECK_ARG_NOT_NULL(m_env.window_handle);
     
-    RECT            window_rect{};
-    int32_t         window_style    = WS_OVERLAPPEDWINDOW;
-    int32_t         window_mode     = 0;
-    HWND            window_position = nullptr;
-    const Settings& app_settings    = GetPlatformAppSettings();
+    RECT    window_rect{};
+    int32_t window_style    = WS_OVERLAPPEDWINDOW;
+    int32_t window_mode     = 0;
+    HWND    window_position = nullptr;
 
-    if (app_settings.is_full_screen)
+    if (GetPlatformAppSettings().is_full_screen)
     {
         GetWindowRect(m_env.window_handle, &m_window_rect);
 

--- a/Modules/Platform/AppView/Sources/Methane/Platform/MacOS/AppViewMT.mm
+++ b/Modules/Platform/AppView/Sources/Methane/Platform/MacOS/AppViewMT.mm
@@ -54,7 +54,7 @@ public:
                 META_LOG("Metal Drawable ({}) was presented at {} sec.", mtl_drawable.drawableID, mtl_drawable.presentedTime);
                 const Methane::Data::Timestamp presented_timestamp = Methane::Data::ConvertTimeSecondsToNanoseconds(mtl_drawable.presentedTime);
                 TRACY_GPU_SCOPE_COMPLETE(m_present_scope, Methane::Data::TimeRange(presented_timestamp, presented_timestamp));
-                std::lock_guard<std::mutex> lock(scope_set_mutex);
+                std::scoped_lock<std::mutex> lock(scope_set_mutex);
                 scope_set.erase(*this);
             }];
         }
@@ -291,7 +291,7 @@ static CVReturn DispatchRenderLoop(CVDisplayLinkRef /*display_link*/,
     TRACY_GPU_SCOPE_BEGIN(gpu_scope, "Request/Present Metal Drawable");
     m_current_drawable = [self.metalLayer nextDrawable];
     TRACY_GPU_SCOPE_END(gpu_scope);
-    std::lock_guard<std::mutex> lock(m_present_scopes_mutex);
+    std::scoped_lock<std::mutex> lock(m_present_scopes_mutex);
     m_present_scopes.try_emplace(m_current_drawable, std::move(gpu_scope), m_present_scopes, m_present_scopes_mutex);
 #else
     m_current_drawable = [self.metalLayer nextDrawable];

--- a/Modules/Platform/AppView/Sources/Methane/Platform/MacOS/AppViewMT.mm
+++ b/Modules/Platform/AppView/Sources/Methane/Platform/MacOS/AppViewMT.mm
@@ -292,7 +292,7 @@ static CVReturn DispatchRenderLoop(CVDisplayLinkRef /*display_link*/,
     m_current_drawable = [self.metalLayer nextDrawable];
     TRACY_GPU_SCOPE_END(gpu_scope);
     std::lock_guard<std::mutex> lock(m_present_scopes_mutex);
-    m_present_scopes.emplace(m_current_drawable, std::move(gpu_scope), m_present_scopes, m_present_scopes_mutex);
+    m_present_scopes.try_emplace(m_current_drawable, std::move(gpu_scope), m_present_scopes, m_present_scopes_mutex);
 #else
     m_current_drawable = [self.metalLayer nextDrawable];
 #endif

--- a/Modules/Platform/Input/Include/Methane/Platform/Input/Controller.h
+++ b/Modules/Platform/Input/Include/Methane/Platform/Input/Controller.h
@@ -62,9 +62,9 @@ class Controller
 public:
     explicit Controller(const std::string& name) : m_name(name) { }
 
-    const std::string& GetControllerName() const { return m_name; }
-    bool IsEnabled() const { return m_is_enabled; }
-    void SetEnabled(bool is_enabled) { m_is_enabled = is_enabled; }
+    [[nodiscard]] const std::string& GetControllerName() const { return m_name; }
+    [[nodiscard]] bool IsEnabled() const                       { return m_is_enabled; }
+    void SetEnabled(bool is_enabled)                           { m_is_enabled = is_enabled; }
 
     // IController - overrides are optional
     void OnMouseButtonChanged(Mouse::Button /*button*/, Mouse::ButtonState /*button_state*/, const Mouse::StateChange& /*state_change*/) override { /* empty by default */ }
@@ -75,7 +75,7 @@ public:
     void OnModifiersChanged(Keyboard::Modifiers /*modifiers*/, const Keyboard::StateChange& /*state_change*/) override { /* empty by default */ }
     
     // IHelpProvider - overrides are optional
-    HelpLines GetHelp() const override { return HelpLines(); }
+    [[nodiscard]] HelpLines GetHelp() const override { return HelpLines(); }
 
 private:
     std::string m_name;

--- a/Modules/Platform/Input/Include/Methane/Platform/Input/State.h
+++ b/Modules/Platform/Input/Include/Methane/Platform/Input/State.h
@@ -36,11 +36,12 @@ public:
     State() = default;
     explicit State(const ControllersPool& controllers) : m_controllers(controllers) {}
 
-    const ControllersPool&  GetControllers() const noexcept                     { return m_controllers; }
-    void                    AddControllers(const Ptrs<Controller>& controllers) { m_controllers.insert(m_controllers.end(), controllers.begin(), controllers.end()); }
+    [[nodiscard]] const ControllersPool& GetControllers() const noexcept { return m_controllers; }
 
-    const Keyboard::State& GetKeyboardState() const noexcept { return m_keyboard_state; }
-    const Mouse::State&    GetMouseState() const noexcept    { return m_mouse_state; }
+    void AddControllers(const Ptrs<Controller>& controllers) { m_controllers.insert(m_controllers.end(), controllers.begin(), controllers.end()); }
+
+    [[nodiscard]] const Keyboard::State& GetKeyboardState() const noexcept { return m_keyboard_state; }
+    [[nodiscard]] const Mouse::State&    GetMouseState() const noexcept    { return m_mouse_state; }
 
     // IActionController
     void OnMouseButtonChanged(Mouse::Button button, Mouse::ButtonState button_state) override;
@@ -53,7 +54,7 @@ public:
     void ReleaseAllKeys();
 
     template<typename ControllerT, typename = std::enable_if_t<std::is_base_of_v<Controller, ControllerT>>>
-    Refs<ControllerT> GetControllersOfType() const
+    [[nodiscard]] Refs<ControllerT> GetControllersOfType() const
     {
         META_FUNCTION_TASK();
         Refs<ControllerT> controllers;

--- a/Modules/Platform/Input/Include/Methane/Platform/Input/State.h
+++ b/Modules/Platform/Input/Include/Methane/Platform/Input/State.h
@@ -25,6 +25,7 @@ Aggregated application input state with controllers.
 
 #include "ControllersPool.h"
 
+#include <Methane/Checks.hpp>
 #include <Methane/Instrumentation.h>
 
 namespace Methane::Platform::Input
@@ -61,8 +62,10 @@ public:
         const std::type_info& controller_type  = typeid(ControllerT);
         for(const Ptr<Controller>& controller_ptr : m_controllers)
         {
-            if (controller_ptr && typeid(*controller_ptr) == controller_type)
-                controllers.emplace_back(static_cast<ControllerT&>(*controller_ptr));
+            META_CHECK_ARG_NOT_NULL(controller_ptr);
+            if (Controller& controller = *controller_ptr;
+                typeid(controller) == controller_type)
+                controllers.emplace_back(static_cast<ControllerT&>(controller));
         }
         return controllers;
     }

--- a/Modules/Platform/Input/Include/Methane/Platform/Input/State.h
+++ b/Modules/Platform/Input/Include/Methane/Platform/Input/State.h
@@ -61,11 +61,7 @@ public:
         const std::type_info& controller_type  = typeid(ControllerT);
         for(const Ptr<Controller>& controller_ptr : m_controllers)
         {
-            if (!controller_ptr)
-                continue;
-
-            const Controller& controller = *controller_ptr;
-            if (typeid(controller) == controller_type)
+            if (controller_ptr && typeid(*controller_ptr) == controller_type)
                 controllers.emplace_back(static_cast<ControllerT&>(*controller_ptr));
         }
         return controllers;

--- a/Modules/Platform/Input/Include/Methane/Platform/Keyboard.h
+++ b/Modules/Platform/Input/Include/Methane/Platform/Keyboard.h
@@ -129,19 +129,20 @@ public:
     KeyConverter(Key key, Modifiers modifiers);
     explicit KeyConverter(const NativeKey& native_key);
     
-    Key         GetKey() const noexcept         { return m_key; }
-    Modifiers   GetModifiers() const noexcept   { return m_modifiers; }
-    Modifiers   GetModifierKey() const noexcept;
-    std::string ToString() const;
+    [[nodiscard]] Key         GetKey() const noexcept         { return m_key; }
+    [[nodiscard]] Modifiers   GetModifiers() const noexcept   { return m_modifiers; }
+    [[nodiscard]] Modifiers   GetModifierKey() const noexcept;
+    [[nodiscard]] std::string ToString() const;
     
     // NOTE: Platform dependent functions: see MacOS, Windows subdirs for implementation
-    static Key       GetKeyByNativeCode(const NativeKey& native_key);
-    static Modifiers GetModifiersByNativeCode(const NativeKey& native_key);
+    [[nodiscard]] static Key       GetKeyByNativeCode(const NativeKey& native_key);
+    [[nodiscard]] static Modifiers GetModifiersByNativeCode(const NativeKey& native_key);
     
 private:
+    [[nodiscard]] static Key GetControlKey(const NativeKey& native_key);
+
     const Key       m_key;
     const Modifiers m_modifiers;
-    static Key GetControlKey(const NativeKey& native_key);
 };
 
 enum class KeyState : uint8_t
@@ -166,12 +167,12 @@ public:
     State() = default;
     State(std::initializer_list<Key> pressed_keys, Modifiers modifiers_mask = Modifiers::None);
 
-    bool   operator<(const State& other) const noexcept;
-    bool   operator==(const State& other) const noexcept;
-    bool   operator!=(const State& other) const noexcept    { return !operator==(other); }
-    const  KeyState& operator[](Key key) const noexcept     { return m_key_states[static_cast<size_t>(key)]; }
-    explicit operator std::string() const                   { return ToString(); }
-    explicit operator bool() const noexcept;
+    [[nodiscard]] bool operator<(const State& other) const noexcept;
+    [[nodiscard]] bool operator==(const State& other) const noexcept;
+    [[nodiscard]] bool operator!=(const State& other) const noexcept    { return !operator==(other); }
+    [[nodiscard]] const  KeyState& operator[](Key key) const noexcept     { return m_key_states[static_cast<size_t>(key)]; }
+    [[nodiscard]] explicit operator std::string() const                   { return ToString(); }
+    [[nodiscard]] explicit operator bool() const noexcept;
 
     virtual KeyType SetKey(Key key, KeyState key_state);
 
@@ -179,11 +180,11 @@ public:
     void    PressKey(Key key)                               { SetKey(key, KeyState::Pressed); }
     void    ReleaseKey(Key key)                             { SetKey(key, KeyState::Released); }
 
-    Keys             GetPressedKeys() const noexcept;
-    const KeyStates& GetKeyStates() const noexcept          { return m_key_states; }
-    Modifiers        GetModifiersMask() const noexcept      { return m_modifiers_mask; }
-    Properties       GetDiff(const State& other) const noexcept;
-    std::string      ToString() const;
+    [[nodiscard]] Keys             GetPressedKeys() const noexcept;
+    [[nodiscard]] const KeyStates& GetKeyStates() const noexcept          { return m_key_states; }
+    [[nodiscard]] Modifiers        GetModifiersMask() const noexcept      { return m_modifiers_mask; }
+    [[nodiscard]] Properties       GetDiff(const State& other) const noexcept;
+    [[nodiscard]] std::string      ToString() const;
 
 private:
     KeyType SetKeyImpl(Key key, KeyState key_state);
@@ -209,8 +210,8 @@ public:
 
     KeyType SetKey(Key key, KeyState key_state) override;
 
-    const Keys& GetPressedModifierKeys() const { return m_pressed_modifier_keys; }
-    Keys        GetAllPressedKeys() const;
+    [[nodiscard]] const Keys& GetPressedModifierKeys() const { return m_pressed_modifier_keys; }
+    [[nodiscard]] Keys        GetAllPressedKeys() const;
 
 private:
     void SetModifierKey(Key key, KeyState key_state);

--- a/Modules/Platform/Input/Include/Methane/Platform/KeyboardActionControllerBase.hpp
+++ b/Modules/Platform/Input/Include/Methane/Platform/KeyboardActionControllerBase.hpp
@@ -49,6 +49,7 @@ public:
         META_FUNCTION_TASK();
     }
 
+    [[nodiscard]]
     size_t GetKeyboardActionsCount() const noexcept { return m_action_by_keyboard_key.size() + m_action_by_keyboard_state.size(); }
     
     void OnKeyboardChanged(Key button, KeyState key_state, const StateChange& state_change)
@@ -69,7 +70,8 @@ public:
             OnKeyboardKeyAction(action_by_keyboard_key_it->second, key_state);
         }
     }
-    
+
+    [[nodiscard]]
     Input::IHelpProvider::HelpLines GetKeyboardHelp() const
     {
         META_FUNCTION_TASK();
@@ -106,6 +108,7 @@ public:
         return help_lines;
     }
 
+    [[nodiscard]]
     Keyboard::State GetKeyboardStateByAction(ActionEnum action) const noexcept
     {
         META_FUNCTION_TASK();
@@ -120,6 +123,7 @@ public:
         return Keyboard::State();
     }
 
+    [[nodiscard]]
     static const State& GetKeyboardStateByAction(const ActionByKeyboardState& action_by_keyboard_state, ActionEnum action) noexcept
     {
         META_FUNCTION_TASK();
@@ -132,6 +136,7 @@ public:
         return action_by_keyboard_state_it == action_by_keyboard_state.end() ? empty_state : action_by_keyboard_state_it->first;
     }
 
+    [[nodiscard]]
     static Key GetKeyboardKeyByAction(const ActionByKeyboardKey& action_by_key, ActionEnum action) noexcept
     {
         META_FUNCTION_TASK();
@@ -145,10 +150,11 @@ public:
     
 protected:
     // Keyboard::ActionControllerBase interface
-    virtual void        OnKeyboardKeyAction(ActionEnum action, KeyState key_state) = 0;
-    virtual void        OnKeyboardStateAction(ActionEnum action) = 0;
-    virtual std::string GetKeyboardActionName(ActionEnum action) const = 0;
+    virtual void OnKeyboardKeyAction(ActionEnum action, KeyState key_state) = 0;
+    virtual void OnKeyboardStateAction(ActionEnum action) = 0;
+    [[nodiscard]] virtual std::string GetKeyboardActionName(ActionEnum action) const = 0;
 
+    [[nodiscard]]
     ActionEnum GetKeyboardActionByState(const State& state) const
     {
         META_FUNCTION_TASK();
@@ -156,7 +162,8 @@ protected:
         return (action_by_keyboard_state_it != m_action_by_keyboard_state.end())
               ? action_by_keyboard_state_it->second : ActionEnum::None;
     }
-    
+
+    [[nodiscard]]
     ActionEnum GetKeyboardActionByKey(Key key) const
     {
         META_FUNCTION_TASK();

--- a/Modules/Platform/Input/Include/Methane/Platform/KeyboardActionControllerBase.hpp
+++ b/Modules/Platform/Input/Include/Methane/Platform/KeyboardActionControllerBase.hpp
@@ -112,12 +112,10 @@ public:
     Keyboard::State GetKeyboardStateByAction(ActionEnum action) const noexcept
     {
         META_FUNCTION_TASK();
-        const State& key_state = GetKeyboardStateByAction(m_action_by_keyboard_state, action);
-        if (key_state)
+        if (const State& key_state = GetKeyboardStateByAction(m_action_by_keyboard_state, action); key_state)
             return key_state;
 
-        const Key key = GetKeyboardKeyByAction(m_action_by_keyboard_key, action);
-        if (key != Key::Unknown)
+        if (const Key key = GetKeyboardKeyByAction(m_action_by_keyboard_key, action); key != Key::Unknown)
             return Keyboard::State({ key });
 
         return Keyboard::State();

--- a/Modules/Platform/Input/Include/Methane/Platform/KeyboardActionControllerBase.hpp
+++ b/Modules/Platform/Input/Include/Methane/Platform/KeyboardActionControllerBase.hpp
@@ -58,14 +58,14 @@ public:
         if (state_change.changed_properties == State::Properties::None)
             return;
         
-        const auto action_by_keyboard_state_it = m_action_by_keyboard_state.find(state_change.current);
-        if (action_by_keyboard_state_it != m_action_by_keyboard_state.end())
+        if (const auto action_by_keyboard_state_it = m_action_by_keyboard_state.find(state_change.current);
+            action_by_keyboard_state_it != m_action_by_keyboard_state.end())
         {
             OnKeyboardStateAction(action_by_keyboard_state_it->second);
         }
         
-        const auto action_by_keyboard_key_it = m_action_by_keyboard_key.find(button);
-        if (action_by_keyboard_key_it != m_action_by_keyboard_key.end())
+        if (const auto action_by_keyboard_key_it = m_action_by_keyboard_key.find(button);
+            action_by_keyboard_key_it != m_action_by_keyboard_key.end())
         {
             OnKeyboardKeyAction(action_by_keyboard_key_it->second, key_state);
         }
@@ -82,10 +82,10 @@ public:
         help_lines.reserve(m_action_by_keyboard_key.size() + m_action_by_keyboard_state.size());
         for (const ActionEnum action : magic_enum::enum_values<ActionEnum>())
         {
-            const auto action_by_keyboard_state_it = std::find_if(m_action_by_keyboard_state.begin(), m_action_by_keyboard_state.end(),
-                                                                  [action](const std::pair<Keyboard::State, ActionEnum>& keys_and_action)
-                                                                  { return keys_and_action.second == action; });
-            if (action_by_keyboard_state_it != m_action_by_keyboard_state.end())
+            if (const auto action_by_keyboard_state_it = std::find_if(m_action_by_keyboard_state.begin(), m_action_by_keyboard_state.end(),
+                                                                      [action](const std::pair<Keyboard::State, ActionEnum>& keys_and_action)
+                                                                      { return keys_and_action.second == action; });
+                action_by_keyboard_state_it != m_action_by_keyboard_state.end())
             {
                 help_lines.push_back({
                     action_by_keyboard_state_it->first.ToString(),
@@ -93,10 +93,10 @@ public:
                 });
             }
             
-            const auto action_by_keyboard_key_it = std::find_if(m_action_by_keyboard_key.begin(), m_action_by_keyboard_key.end(),
-                                                                [action](const std::pair<Keyboard::Key, ActionEnum>& key_and_action)
-                                                                { return key_and_action.second == action; });
-            if (action_by_keyboard_key_it != m_action_by_keyboard_key.end())
+            if (const auto action_by_keyboard_key_it = std::find_if(m_action_by_keyboard_key.begin(), m_action_by_keyboard_key.end(),
+                                                                    [action](const std::pair<Keyboard::Key, ActionEnum>& key_and_action)
+                                                                    { return key_and_action.second == action; });
+                action_by_keyboard_key_it != m_action_by_keyboard_key.end())
             {
                 help_lines.push_back({
                     Keyboard::KeyConverter(action_by_keyboard_key_it->first).ToString(),

--- a/Modules/Platform/Input/Include/Methane/Platform/Mouse.h
+++ b/Modules/Platform/Input/Include/Methane/Platform/Mouse.h
@@ -56,8 +56,8 @@ class ButtonConverter
 {
 public:
     explicit ButtonConverter(Button button) : m_button(button) { }
-    
-    std::string ToString() const;
+
+    [[nodiscard]] std::string ToString() const;
     
 private:
     Button m_button;
@@ -75,7 +75,7 @@ using Position = Data::Point2i;
 using Scroll = Data::Point2f;
 
 using MouseButtonAndDelta = std::pair<Mouse::Button, float>;
-inline MouseButtonAndDelta GetScrollButtonAndDelta(const Scroll& scroll_delta)
+[[nodiscard]] inline MouseButtonAndDelta GetScrollButtonAndDelta(const Scroll& scroll_delta)
 {
     constexpr float min_scroll_delta = 0.00001F;
     if (std::fabs(scroll_delta.GetY()) > min_scroll_delta)
@@ -102,29 +102,26 @@ public:
     State() = default;
     State(std::initializer_list<Button> pressed_buttons, const Position& position = Position(), const Scroll& scroll = Scroll(), bool in_window = false);
 
-    bool operator==(const State& other) const;
-    bool operator!=(const State& other) const                   { return !operator==(other); }
-    const ButtonState& operator[](Button button) const          { return m_button_states[static_cast<size_t>(button)]; }
-    explicit operator std::string() const                       { return ToString(); }
+    [[nodiscard]] bool operator==(const State& other) const;
+    [[nodiscard]] bool operator!=(const State& other) const          { return !operator==(other); }
+    [[nodiscard]] const ButtonState& operator[](Button button) const { return m_button_states[static_cast<size_t>(button)]; }
+    [[nodiscard]] explicit operator std::string() const              { return ToString(); }
 
-    void  SetButton(Button button, ButtonState state)           { m_button_states[static_cast<size_t>(button)] = state; }
-    void  PressButton(Button button)                            { SetButton(button, ButtonState::Pressed); }
-    void  ReleaseButton(Button button)                          { SetButton(button, ButtonState::Released); }
-    
-    const Position&     GetPosition() const                     { return m_position; }
-    void                SetPosition(const Position& position)   { m_position = position; }
+    void SetButton(Button button, ButtonState state) { m_button_states[static_cast<size_t>(button)] = state; }
+    void PressButton(Button button)                  { SetButton(button, ButtonState::Pressed); }
+    void ReleaseButton(Button button)                { SetButton(button, ButtonState::Released); }
+    void SetPosition(const Position& position)       { m_position = position; }
+    void SetInWindow(bool in_window)                 { m_in_window = in_window; }
+    void AddScrollDelta(const Scroll& delta)         { m_scroll += delta; }
+    void ResetScroll();
 
-    const Scroll&       GetScroll() const                       { return m_scroll; }
-    void                AddScrollDelta(const Scroll& delta)     { m_scroll += delta; }
-    void                ResetScroll();
-
-    bool                IsInWindow() const                      { return m_in_window; }
-    void                SetInWindow(bool in_window)             { m_in_window = in_window; }
-
-    Buttons             GetPressedButtons() const;
-    const ButtonStates& GetButtonStates() const                 { return m_button_states; }
-    Properties          GetDiff(const State& other) const;
-    std::string         ToString() const;
+    [[nodiscard]] const Position&     GetPosition() const                     { return m_position; }
+    [[nodiscard]] const Scroll&       GetScroll() const                       { return m_scroll; }
+    [[nodiscard]] bool                IsInWindow() const                      { return m_in_window; }
+    [[nodiscard]] const ButtonStates& GetButtonStates() const                 { return m_button_states; }
+    [[nodiscard]] Buttons             GetPressedButtons() const;
+    [[nodiscard]] Properties          GetDiff(const State& other) const;
+    [[nodiscard]] std::string         ToString() const;
 
 private:
     ButtonStates m_button_states { };

--- a/Modules/Platform/Input/Include/Methane/Platform/MouseActionControllerBase.hpp
+++ b/Modules/Platform/Input/Include/Methane/Platform/MouseActionControllerBase.hpp
@@ -44,8 +44,10 @@ public:
         META_FUNCTION_TASK();
     }
 
+    [[nodiscard]]
     size_t GetMouseActionsCount() const noexcept { return m_action_by_mouse_button.size(); }
-    
+
+    [[nodiscard]]
     Input::IHelpProvider::HelpLines GetMouseHelp() const
     {
         META_FUNCTION_TASK();
@@ -75,8 +77,9 @@ public:
     
 protected:
     // Mouse::ActionControllerBase interface
-    virtual std::string GetMouseActionName(ActionEnum action) const = 0;
-    
+    [[nodiscard]] virtual std::string GetMouseActionName(ActionEnum action) const = 0;
+
+    [[nodiscard]]
     ActionEnum GetMouseActionByButton(Button mouse_button) const
     {
         META_FUNCTION_TASK();

--- a/Modules/Platform/Input/Sources/Methane/Platform/Input/ControllersPool.cpp
+++ b/Modules/Platform/Input/Sources/Methane/Platform/Input/ControllersPool.cpp
@@ -143,7 +143,7 @@ IHelpProvider::HelpLines ControllersPool::GetHelp() const
 
         const HelpLines help_lines = controller_ptr->GetHelp();
 
-        all_help_lines.push_back({ "", controller_ptr->GetControllerName() });
+        all_help_lines.emplace_back("", controller_ptr->GetControllerName());
         all_help_lines.insert(all_help_lines.end(), help_lines.begin(), help_lines.end());
     }
     return all_help_lines;

--- a/Modules/Platform/Input/Sources/Methane/Platform/Keyboard.cpp
+++ b/Modules/Platform/Input/Sources/Methane/Platform/Keyboard.cpp
@@ -296,8 +296,8 @@ KeyType State::SetKeyImpl(Key key, KeyState key_state)
     if (key == Key::Unknown)
         return KeyType::Common;
 
-    const Modifiers key_modifier = KeyConverter(key).GetModifierKey();
-    if (key_modifier != Modifiers::None)
+    if (const Modifiers key_modifier = KeyConverter(key).GetModifierKey();
+        key_modifier != Modifiers::None)
     {
         UpdateModifiersMask(key_modifier, key_state == KeyState::Pressed);
         return KeyType::Modifier;
@@ -349,8 +349,8 @@ StateExt::StateExt(std::initializer_list<Key> pressed_keys, Modifiers modifiers_
 KeyType StateExt::SetKey(Key key, KeyState key_state)
 {
     META_FUNCTION_TASK();
-    const KeyType key_type = State::SetKey(key, key_state);
-    if (key_type != KeyType::Modifier)
+    if (const KeyType key_type = State::SetKey(key, key_state);
+        key_type != KeyType::Modifier)
         return key_type;
 
     SetModifierKey(key, key_state);

--- a/Modules/Platform/Utils/Include/Methane/Platform/Logger.h
+++ b/Modules/Platform/Utils/Include/Methane/Platform/Logger.h
@@ -33,7 +33,7 @@ namespace Methane::Platform
 class Logger : public ILogger
 {
     // Data::ILogger interface
-    void Log(const std::string& message) override
+    void Log(std::string_view message) override
     {
         PrintToDebugOutput(message);
     }

--- a/Modules/Platform/Utils/Include/Methane/Platform/Utils.h
+++ b/Modules/Platform/Utils/Include/Methane/Platform/Utils.h
@@ -38,12 +38,13 @@ Methane platform utility functions
 #endif
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace Methane::Platform
 {
 
-void PrintToDebugOutput(const std::string& msg);
+void PrintToDebugOutput(std::string_view msg);
 std::string GetExecutableDir();
 std::string GetExecutableFileName();
 std::string GetResourceDir();

--- a/Modules/Platform/Utils/Sources/Methane/Platform/Linux/Utils.cpp
+++ b/Modules/Platform/Utils/Sources/Methane/Platform/Linux/Utils.cpp
@@ -26,14 +26,15 @@ MacOS platform utility functions.
 #include <Methane/Checks.hpp>
 
 #include <stdexcept>
+#include <string_view>
 
 namespace Methane::Platform
 {
 
-void PrintToDebugOutput(__attribute__((unused)) const std::string& msg)
+void PrintToDebugOutput(__attribute__((unused)) std::string_view msg)
 {
     META_FUNCTION_TASK();
-    TracyMessage(msg.c_str(), msg.size());
+    TracyMessage(msg.data(), msg.size());
 }
 
 std::string GetExecutableDir()

--- a/Modules/Platform/Utils/Sources/Methane/Platform/MacOS/Utils.mm
+++ b/Modules/Platform/Utils/Sources/Methane/Platform/MacOS/Utils.mm
@@ -27,14 +27,16 @@ MacOS platform utility functions.
 
 #import <AppKit/AppKit.h>
 
+#include <string_view>
+
 namespace Methane::Platform
 {
 
-void PrintToDebugOutput(const std::string& msg)
+void PrintToDebugOutput(std::string_view msg)
 {
     META_FUNCTION_TASK();
-    NSLog(@"%s", msg.c_str());
-    TracyMessage(msg.c_str(), msg.size());
+    NSLog(@"%s", msg.data());
+    TracyMessage(msg.data(), msg.size());
 }
 
 std::string GetExecutableDir()

--- a/Modules/Platform/Utils/Sources/Methane/Platform/Windows/Utils.cpp
+++ b/Modules/Platform/Utils/Sources/Methane/Platform/Windows/Utils.cpp
@@ -29,15 +29,16 @@ Windows platform utility functions.
 #include <shellapi.h>
 
 #include <nowide/convert.hpp>
+#include <string_view>
 
 namespace Methane::Platform
 {
 
-void PrintToDebugOutput(const std::string& msg)
+void PrintToDebugOutput(std::string_view msg)
 {
     META_FUNCTION_TASK();
     OutputDebugStringA(fmt::format("{}\n", msg).c_str());
-    TracyMessage(msg.c_str(), msg.size());
+    TracyMessage(msg.data(), msg.size());
 }
 
 inline std::wstring GetExecutableFilePath()

--- a/Modules/Platform/Utils/Sources/Methane/Platform/Windows/Utils.cpp
+++ b/Modules/Platform/Utils/Sources/Methane/Platform/Windows/Utils.cpp
@@ -100,7 +100,7 @@ bool IsDeveloperModeEnabled() noexcept
 
     DWORD value{};
     DWORD dword_size = sizeof(DWORD);
-    err = RegQueryValueExW(h_key, L"AllowDevelopmentWithoutDevLicense", nullptr, nullptr, reinterpret_cast<LPBYTE>(&value), &dword_size);
+    err = RegQueryValueExW(h_key, L"AllowDevelopmentWithoutDevLicense", nullptr, nullptr, reinterpret_cast<LPBYTE>(&value), &dword_size); // NOSONAR
     RegCloseKey(h_key);
     if (err != ERROR_SUCCESS)
         return false;

--- a/Modules/UserInterface/App/Include/Methane/UserInterface/AppBase.h
+++ b/Modules/UserInterface/App/Include/Methane/UserInterface/AppBase.h
@@ -27,6 +27,8 @@ Base implementation of the Methane user interface application.
 
 #include <Methane/UserInterface/HeadsUpDisplay.h>
 
+#include <string_view>
+
 namespace Methane::UserInterface
 {
 
@@ -56,8 +58,8 @@ protected:
     void RenderOverlay(gfx::RenderCommandList& cmd_list) const;
 
     bool SetHeadsUpDisplayUIMode(IApp::HeadsUpDisplayMode heads_up_display_mode);
-    bool SetHelpText(const std::string& help_str);
-    bool SetParametersText(const std::string& parameters_str);
+    bool SetHelpText(std::string_view help_str);
+    bool SetParametersText(std::string_view parameters_str);
 
     [[nodiscard]] bool IsHelpTextDisplayed() const noexcept                    { return !m_help_columns.first.text_str.empty(); }
     [[nodiscard]] bool IsParametersTextDisplayed() const noexcept              { return !m_parameters.text_str.empty(); }

--- a/Modules/UserInterface/App/Include/Methane/UserInterface/AppBase.h
+++ b/Modules/UserInterface/App/Include/Methane/UserInterface/AppBase.h
@@ -59,19 +59,18 @@ protected:
     bool SetHelpText(const std::string& help_str);
     bool SetParametersText(const std::string& parameters_str);
 
-    bool IsHelpTextDisplayed() const noexcept                    { return !m_help_columns.first.text_str.empty(); }
-    bool IsParametersTextDisplayed() const noexcept              { return !m_parameters.text_str.empty(); }
-    void GetParametersText(const std::string& parameters_str) const;
-    Font& GetMainFont();
+    [[nodiscard]] bool IsHelpTextDisplayed() const noexcept                    { return !m_help_columns.first.text_str.empty(); }
+    [[nodiscard]] bool IsParametersTextDisplayed() const noexcept              { return !m_parameters.text_str.empty(); }
+    [[nodiscard]] Font& GetMainFont();
 
-    const IApp::Settings& GetAppSettings() const noexcept        { return m_app_settings; }
+    [[nodiscard]] const IApp::Settings& GetAppSettings() const noexcept        { return m_app_settings; }
 
-    HeadsUpDisplay::Settings& GetHeadsUpDisplaySettings()        { return m_app_settings.hud_settings; }
-    HeadsUpDisplay*           GetHeadsUpDisplay() const noexcept { return m_hud_ptr.get(); }
+    [[nodiscard]] HeadsUpDisplay::Settings& GetHeadsUpDisplaySettings()        { return m_app_settings.hud_settings; }
+    [[nodiscard]] HeadsUpDisplay*           GetHeadsUpDisplay() const noexcept { return m_hud_ptr.get(); }
 
-    IApp::Settings& GetAppSettings() noexcept                    { return m_app_settings; }
-    const Context&  GetUIContext() const noexcept                { return *m_ui_context_ptr; }
-    Context&        GetUIContext() noexcept                      { return *m_ui_context_ptr; }
+    [[nodiscard]] IApp::Settings& GetAppSettings() noexcept                    { return m_app_settings; }
+    [[nodiscard]] const Context&  GetUIContext() const noexcept                { return *m_ui_context_ptr; }
+    [[nodiscard]] Context&        GetUIContext() noexcept                      { return *m_ui_context_ptr; }
 
 private:
     struct TextItem

--- a/Modules/UserInterface/App/Sources/Methane/UserInterface/AppBase.cpp
+++ b/Modules/UserInterface/App/Sources/Methane/UserInterface/AppBase.cpp
@@ -31,10 +31,12 @@ Base implementation of the Methane user interface application.
 #include <Methane/Data/AppResourceProviders.h>
 #include <Methane/Instrumentation.h>
 
+#include <string_view>
+
 namespace Methane::UserInterface
 {
 
-static std::vector<size_t> GetLineBreakPositions(const std::string& text_str)
+static std::vector<size_t> GetLineBreakPositions(std::string_view text_str)
 {
     std::vector<size_t> line_break_positions;
     for (size_t line_break_pos = text_str.find('\n', 0);
@@ -46,18 +48,18 @@ static std::vector<size_t> GetLineBreakPositions(const std::string& text_str)
     return line_break_positions;
 }
 
-static void SplitTextToColumns(const std::string& text_str, std::string& left_column_str, std::string& right_column_str)
+static void SplitTextToColumns(std::string_view text_str, std::string& left_column_str, std::string& right_column_str)
 {
     const std::vector<size_t> line_break_positions = GetLineBreakPositions(text_str);
     if (line_break_positions.empty())
     {
-        left_column_str = text_str;
-        right_column_str.clear();
+        left_column_str  = text_str;
+        right_column_str = std::string();
         return;
     }
 
     const size_t middle_line_break_position = line_break_positions[line_break_positions.size() / 2];
-    left_column_str = text_str.substr(0, middle_line_break_position);
+    left_column_str  = text_str.substr(0, middle_line_break_position);
     right_column_str = text_str.substr(middle_line_break_position + 1);
 };
 
@@ -227,7 +229,7 @@ bool AppBase::SetHeadsUpDisplayUIMode(IApp::HeadsUpDisplayMode heads_up_display_
     return true;
 }
 
-bool AppBase::SetHelpText(const std::string& help_str)
+bool AppBase::SetHelpText(std::string_view help_str)
 {
     META_FUNCTION_TASK();
     if (m_help_text_str == help_str)
@@ -266,7 +268,7 @@ bool AppBase::SetHelpText(const std::string& help_str)
     return true;
 }
 
-bool AppBase::SetParametersText(const std::string& parameters_str)
+bool AppBase::SetParametersText(std::string_view parameters_str)
 {
     META_FUNCTION_TASK();
     if (m_parameters.text_str == parameters_str)

--- a/Modules/UserInterface/App/Sources/Methane/UserInterface/AppBase.cpp
+++ b/Modules/UserInterface/App/Sources/Methane/UserInterface/AppBase.cpp
@@ -247,8 +247,8 @@ bool AppBase::SetHelpText(std::string_view help_str)
     // Split help text into two columns
     // when single column does not fit into half of window height
     // and estimated width of two columns first in 2/3 of window width
-    const gfx::FrameSize single_column_size = m_help_columns.first.text_ptr->GetRectInPixels().size;
-    if (single_column_size.height + m_text_margins.GetY() > m_frame_size.height / 2 &&
+    if (const gfx::FrameSize single_column_size = m_help_columns.first.text_ptr->GetRectInPixels().size;
+        single_column_size.height + m_text_margins.GetY() > m_frame_size.height / 2 &&
         single_column_size.width < m_frame_size.width / 2)
     {
         SplitTextToColumns(m_help_text_str, m_help_columns.first.text_str, m_help_columns.second.text_str);

--- a/Modules/UserInterface/Types/Include/Methane/UserInterface/Context.h
+++ b/Modules/UserInterface/Types/Include/Methane/UserInterface/Context.h
@@ -45,56 +45,56 @@ class Context
 public:
     explicit Context(gfx::RenderContext& render_context) noexcept;
 
-    const gfx::RenderContext& GetRenderContext() const noexcept         { return m_render_context; }
-    gfx::RenderContext&       GetRenderContext() noexcept               { return m_render_context; }
+    [[nodiscard]] const gfx::RenderContext& GetRenderContext() const noexcept         { return m_render_context; }
+    [[nodiscard]] gfx::RenderContext&       GetRenderContext() noexcept               { return m_render_context; }
 
-    float     GetDotsToPixelsFactor() const noexcept                    { return m_dots_to_pixels_factor; }
-    uint32_t  GetFontResolutionDpi() const noexcept                     { return m_font_resolution_dpi; }
-    const FrameSize& GetFrameSize() const noexcept;
+    [[nodiscard]] float     GetDotsToPixelsFactor() const noexcept                    { return m_dots_to_pixels_factor; }
+    [[nodiscard]] uint32_t  GetFontResolutionDpi() const noexcept                     { return m_font_resolution_dpi; }
+    [[nodiscard]] const FrameSize& GetFrameSize() const noexcept;
 
-    UnitSize  GetFrameSizeInPixels() const noexcept                     { return UnitSize(Units::Pixels, GetFrameSize()); }
-    UnitSize  GetFrameSizeInDots() const noexcept                       { return UnitSize(Units::Dots, GetFrameSize() / m_dots_to_pixels_factor); }
-    UnitSize  GetFrameSizeInUnits(Units units) const noexcept;
+    [[nodiscard]] UnitSize  GetFrameSizeInPixels() const noexcept                     { return UnitSize(Units::Pixels, GetFrameSize()); }
+    [[nodiscard]] UnitSize  GetFrameSizeInDots() const noexcept                       { return UnitSize(Units::Dots, GetFrameSize() / m_dots_to_pixels_factor); }
+    [[nodiscard]] UnitSize  GetFrameSizeInUnits(Units units) const noexcept;
 
-    UnitPoint ConvertToPixels(const FloatPoint& point) const noexcept;
-    UnitPoint ConvertToDots(const FloatPoint& point) const noexcept;
+    [[nodiscard]] UnitPoint ConvertToPixels(const FloatPoint& point) const noexcept;
+    [[nodiscard]] UnitPoint ConvertToDots(const FloatPoint& point) const noexcept;
 
-    UnitSize  ConvertToPixels(const FloatSize& fsize) const noexcept;
-    UnitSize  ConvertToDots(const FloatSize& fsize) const noexcept;
+    [[nodiscard]] UnitSize  ConvertToPixels(const FloatSize& fsize) const noexcept;
+    [[nodiscard]] UnitSize  ConvertToDots(const FloatSize& fsize) const noexcept;
 
-    UnitRect  ConvertToPixels(const FloatRect& rect) const noexcept;
-    UnitRect  ConvertToDots(const FloatRect& rect) const noexcept;
+    [[nodiscard]] UnitRect  ConvertToPixels(const FloatRect& rect) const noexcept;
+    [[nodiscard]] UnitRect  ConvertToDots(const FloatRect& rect) const noexcept;
 
-    UnitPoint ConvertToPixels(const UnitPoint& point) const noexcept;
-    UnitPoint ConvertToDots(const UnitPoint& point) const noexcept;
-    UnitPoint ConvertToDots(const FramePoint& point_px) const noexcept;
+    [[nodiscard]] UnitPoint ConvertToPixels(const UnitPoint& point) const noexcept;
+    [[nodiscard]] UnitPoint ConvertToDots(const UnitPoint& point) const noexcept;
+    [[nodiscard]] UnitPoint ConvertToDots(const FramePoint& point_px) const noexcept;
 
-    UnitSize  ConvertToPixels(const UnitSize& size) const noexcept;
-    UnitSize  ConvertToDots(const UnitSize& size) const noexcept;
-    UnitSize  ConvertToDots(const FrameSize& size_px) const noexcept;
+    [[nodiscard]] UnitSize  ConvertToPixels(const UnitSize& size) const noexcept;
+    [[nodiscard]] UnitSize  ConvertToDots(const UnitSize& size) const noexcept;
+    [[nodiscard]] UnitSize  ConvertToDots(const FrameSize& size_px) const noexcept;
 
-    UnitRect  ConvertToPixels(const UnitRect& rect) const noexcept;
-    UnitRect  ConvertToDots(const UnitRect& rect) const noexcept;
-    UnitRect  ConvertToDots(const FrameRect& rect_px) const noexcept;
+    [[nodiscard]] UnitRect  ConvertToPixels(const UnitRect& rect) const noexcept;
+    [[nodiscard]] UnitRect  ConvertToDots(const UnitRect& rect) const noexcept;
+    [[nodiscard]] UnitRect  ConvertToDots(const FrameRect& rect_px) const noexcept;
 
-    UnitPoint ConvertToUnits(const FramePoint& point_px, Units units) const noexcept;
-    UnitSize  ConvertToUnits(const FrameSize&  size_px,  Units units) const noexcept;
-    UnitRect  ConvertToUnits(const FrameRect&  rect_px,  Units units) const noexcept;
+    [[nodiscard]] UnitPoint ConvertToUnits(const FramePoint& point_px, Units units) const noexcept;
+    [[nodiscard]] UnitSize  ConvertToUnits(const FrameSize&  size_px,  Units units) const noexcept;
+    [[nodiscard]] UnitRect  ConvertToUnits(const FrameRect&  rect_px,  Units units) const noexcept;
 
     template<typename IntegralT>
-    std::enable_if_t<std::is_integral_v<IntegralT>, IntegralT> ConvertPixelsToDots(const IntegralT& pixels) const noexcept
+    [[nodiscard]] std::enable_if_t<std::is_integral_v<IntegralT>, IntegralT> ConvertPixelsToDots(const IntegralT& pixels) const noexcept
     {
         return static_cast<IntegralT>(std::round(static_cast<float>(pixels) / m_dots_to_pixels_factor));
     }
 
     template<typename IntegralT>
-    std::enable_if_t<std::is_integral_v<IntegralT>, IntegralT> ConvertDotsToPixels(const IntegralT& dots) const noexcept
+    [[nodiscard]] std::enable_if_t<std::is_integral_v<IntegralT>, IntegralT> ConvertDotsToPixels(const IntegralT& dots) const noexcept
     {
         return static_cast<IntegralT>(std::round(static_cast<float>(dots) * m_dots_to_pixels_factor));
     }
 
     template<typename UnitType>
-    UnitType ConvertToUnits(const UnitType& value, Units units) const noexcept
+    [[nodiscard]] UnitType ConvertToUnits(const UnitType& value, Units units) const noexcept
     {
         switch(units)
         {
@@ -105,7 +105,7 @@ public:
     }
 
     template<typename UnitType>
-    bool AreEqual(const UnitType& left, const UnitType& right) const noexcept
+    [[nodiscard]] bool AreEqual(const UnitType& left, const UnitType& right) const noexcept
     {
         if (left.units == right.units)
             return left == right;

--- a/Modules/UserInterface/Types/Sources/Methane/UserInterface/Container.cpp
+++ b/Modules/UserInterface/Types/Sources/Methane/UserInterface/Container.cpp
@@ -38,10 +38,7 @@ Container::Container(Context& ui_context, const UnitRect& ui_rect, const Ptrs<It
 bool Container::AddChild(Item& item)
 {
     META_FUNCTION_TASK();
-    const auto child_it = std::find_if(m_children.begin(), m_children.end(),
-        [&item](const Ptr<Item>& item_ptr) { return item_ptr.get() == std::addressof(item); }
-    );
-    if (child_it != m_children.end())
+    if (std::any_of(m_children.begin(), m_children.end(), [&item](const Ptr<Item>& item_ptr) { return item_ptr.get() == std::addressof(item); }))
         return false;
 
     m_children.emplace_back(item.GetPtr());

--- a/Modules/UserInterface/Typography/Include/Methane/UserInterface/Font.h
+++ b/Modules/UserInterface/Typography/Include/Methane/UserInterface/Font.h
@@ -120,7 +120,7 @@ public:
     private:
         Library();
 
-        using FontByName = std::map<std::string, Ptr<Font>>;
+        using FontByName = std::map<std::string, Ptr<Font>, std::less<>>;
 
         const UniquePtr<Impl> m_impl_ptr;
         FontByName            m_font_by_name;

--- a/Modules/UserInterface/Typography/Include/Methane/UserInterface/Font.h
+++ b/Modules/UserInterface/Typography/Include/Methane/UserInterface/Font.h
@@ -28,6 +28,7 @@ Font atlas textures generation and fonts library management classes.
 #include <Methane/Data/Provider.h>
 #include <Methane/Data/Emitter.hpp>
 
+#include <magic_enum.hpp>
 #include <map>
 #include <string>
 #include <cctype>
@@ -149,8 +150,10 @@ public:
         Char(Code code, gfx::FrameRect rect, gfx::Point2i offset, gfx::Point2i advance, UniquePtr<Glyph>&& glyph_ptr);
 
         [[nodiscard]] Code                  GetCode() const noexcept        { return m_code; }
-        [[nodiscard]] bool                  IsLineBreak() const noexcept    { return static_cast<uint8_t>(m_type_mask) & static_cast<uint8_t>(Type::LineBreak); }
-        [[nodiscard]] bool                  IsWhiteSpace() const noexcept   { return static_cast<uint8_t>(m_type_mask) & static_cast<uint8_t>(Type::Whitespace); }
+        [[nodiscard]] bool                  IsLineBreak() const noexcept    { using namespace magic_enum::bitwise_operators;
+                                                                              return magic_enum::flags::enum_contains(m_type_mask & Type::LineBreak); }
+        [[nodiscard]] bool                  IsWhiteSpace() const noexcept   { using namespace magic_enum::bitwise_operators;
+                                                                              return magic_enum::flags::enum_contains(m_type_mask & Type::Whitespace); }
         [[nodiscard]] const gfx::FrameRect& GetRect() const noexcept        { return m_rect; }
         [[nodiscard]] const gfx::Point2i&   GetOffset() const noexcept      { return m_offset; }
         [[nodiscard]] const gfx::Point2i&   GetAdvance() const noexcept     { return m_advance; }

--- a/Modules/UserInterface/Typography/Include/Methane/UserInterface/Font.h
+++ b/Modules/UserInterface/Typography/Include/Methane/UserInterface/Font.h
@@ -178,8 +178,8 @@ public:
 
     using Chars = Refs<const Char>;
 
-    [[nodiscard]] static std::u32string ConvertUtf8To32(const std::string& text);
-    [[nodiscard]] static std::string    ConvertUtf32To8(const std::u32string& text);
+    [[nodiscard]] static std::u32string ConvertUtf8To32(std::string_view text);
+    [[nodiscard]] static std::string    ConvertUtf32To8(std::u32string_view text);
     [[nodiscard]] static std::u32string GetAlphabetDefault() { return GetAlphabetInRange(32, 126); }
     [[nodiscard]] static std::u32string GetAlphabetInRange(char32_t from, char32_t to);
     [[nodiscard]] static std::u32string GetAlphabetFromText(const std::string& text);

--- a/Modules/UserInterface/Typography/Include/Methane/UserInterface/Font.h
+++ b/Modules/UserInterface/Typography/Include/Methane/UserInterface/Font.h
@@ -90,7 +90,7 @@ public:
     public:
         explicit FreeTypeError(FT_Error error);
 
-        FT_Error GetError() const noexcept { return m_error; }
+        [[nodiscard]] FT_Error GetError() const noexcept { return m_error; }
 
     private:
         const FT_Error m_error;
@@ -102,19 +102,19 @@ public:
         friend class Font;
 
     public:
-        static Library& Get();
+        [[nodiscard]] static Library& Get();
 
-        Refs<Font> GetFonts() const;
-        bool  HasFont(const std::string& font_name) const;
-        Font& GetFont(const std::string& font_name) const;
-        Font& GetFont(const Data::Provider& data_provider, const Settings& font_settings);
+        [[nodiscard]] Refs<Font> GetFonts() const;
+        [[nodiscard]] bool  HasFont(const std::string& font_name) const;
+        [[nodiscard]] Font& GetFont(const std::string& font_name) const;
+        [[nodiscard]] Font& GetFont(const Data::Provider& data_provider, const Settings& font_settings);
         Font& AddFont(const Data::Provider& data_provider, const Settings& font_settings);
         void  RemoveFont(const std::string& font_name);
         void  Clear();
 
     protected:
         class Impl;
-        Impl& GetImpl() { return *m_impl_ptr; }
+        [[nodiscard]] Impl& GetImpl() { return *m_impl_ptr; }
 
     private:
         Library();
@@ -148,17 +148,17 @@ public:
         explicit Char(Code code);
         Char(Code code, gfx::FrameRect rect, gfx::Point2i offset, gfx::Point2i advance, UniquePtr<Glyph>&& glyph_ptr);
 
-        Code                  GetCode() const noexcept        { return m_code; }
-        bool                  IsLineBreak() const noexcept    { return static_cast<uint8_t>(m_type_mask) & static_cast<uint8_t>(Type::LineBreak); }
-        bool                  IsWhiteSpace() const noexcept   { return static_cast<uint8_t>(m_type_mask) & static_cast<uint8_t>(Type::Whitespace); }
-        const gfx::FrameRect& GetRect() const noexcept        { return m_rect; }
-        const gfx::Point2i&   GetOffset() const noexcept      { return m_offset; }
-        const gfx::Point2i&   GetAdvance() const noexcept     { return m_advance; }
-        const gfx::FrameSize& GetVisualSize() const noexcept  { return m_visual_size; }
+        [[nodiscard]] Code                  GetCode() const noexcept        { return m_code; }
+        [[nodiscard]] bool                  IsLineBreak() const noexcept    { return static_cast<uint8_t>(m_type_mask) & static_cast<uint8_t>(Type::LineBreak); }
+        [[nodiscard]] bool                  IsWhiteSpace() const noexcept   { return static_cast<uint8_t>(m_type_mask) & static_cast<uint8_t>(Type::Whitespace); }
+        [[nodiscard]] const gfx::FrameRect& GetRect() const noexcept        { return m_rect; }
+        [[nodiscard]] const gfx::Point2i&   GetOffset() const noexcept      { return m_offset; }
+        [[nodiscard]] const gfx::Point2i&   GetAdvance() const noexcept     { return m_advance; }
+        [[nodiscard]] const gfx::FrameSize& GetVisualSize() const noexcept  { return m_visual_size; }
 
-        bool operator<(const Char& other) const noexcept      { return m_rect.size.GetPixelsCount() < other.m_rect.size.GetPixelsCount(); }
-        bool operator>(const Char& other) const noexcept      { return m_rect.size.GetPixelsCount() > other.m_rect.size.GetPixelsCount(); }
-        explicit operator bool() const noexcept               { return m_code != 0U; }
+        [[nodiscard]] bool operator<(const Char& other) const noexcept      { return m_rect.size.GetPixelsCount() < other.m_rect.size.GetPixelsCount(); }
+        [[nodiscard]] bool operator>(const Char& other) const noexcept      { return m_rect.size.GetPixelsCount() > other.m_rect.size.GetPixelsCount(); }
+        [[nodiscard]] explicit operator bool() const noexcept               { return m_code != 0U; }
 
         void     DrawToAtlas(Data::Bytes& atlas_bitmap, uint32_t atlas_row_stride) const;
         uint32_t GetGlyphIndex() const;
@@ -175,34 +175,35 @@ public:
 
     using Chars = Refs<const Char>;
 
-    static std::u32string ConvertUtf8To32(const std::string& text);
-    static std::string    ConvertUtf32To8(const std::u32string& text);
-    static std::u32string GetAlphabetDefault() { return GetAlphabetInRange(32, 126); }
-    static std::u32string GetAlphabetInRange(char32_t from, char32_t to);
-    static std::u32string GetAlphabetFromText(const std::string& text);
-    static std::u32string GetAlphabetFromText(const std::u32string& text);
+    [[nodiscard]] static std::u32string ConvertUtf8To32(const std::string& text);
+    [[nodiscard]] static std::string    ConvertUtf32To8(const std::u32string& text);
+    [[nodiscard]] static std::u32string GetAlphabetDefault() { return GetAlphabetInRange(32, 126); }
+    [[nodiscard]] static std::u32string GetAlphabetInRange(char32_t from, char32_t to);
+    [[nodiscard]] static std::u32string GetAlphabetFromText(const std::string& text);
+    [[nodiscard]] static std::u32string GetAlphabetFromText(const std::u32string& text);
 
     ~Font() override;
 
-    Ptr<Font>       GetPtr()            { return shared_from_this(); }
-    const Settings& GetSettings() const { return m_settings; }
+    [[nodiscard]] Ptr<Font>       GetPtr()            { return shared_from_this(); }
+    [[nodiscard]] const Settings& GetSettings() const { return m_settings; }
 
     void                     ResetChars(const std::string& utf8_characters);
     void                     ResetChars(const std::u32string& utf32_characters);
     void                     AddChars(const std::string& utf8_characters);
     void                     AddChars(const std::u32string& utf32_characters);
     const Font::Char&        AddChar(Char::Code char_code);
-    bool                     HasChar(Char::Code char_code) const;
-    const Char&              GetChar(Char::Code char_code) const;
-    Chars                    GetChars() const;
-    Chars                    GetTextChars(const std::string& text);
-    Chars                    GetTextChars(const std::u32string& text);
-    gfx:: FramePoint         GetKerning(const Char& left_char, const Char& right_char) const;
-    uint32_t                 GetLineHeight() const;
-    const gfx::FrameSize&    GetMaxGlyphSize() const noexcept { return m_max_glyph_size; }
-    const gfx::FrameSize&    GetAtlasSize() const noexcept;
-    const Ptr<gfx::Texture>& GetAtlasTexturePtr(gfx::Context& context);
-    gfx::Texture&            GetAtlasTexture(gfx::Context& context);
+    
+    [[nodiscard]] bool                     HasChar(Char::Code char_code) const;
+    [[nodiscard]] const Char&              GetChar(Char::Code char_code) const;
+    [[nodiscard]] Chars                    GetChars() const;
+    [[nodiscard]] Chars                    GetTextChars(const std::string& text);
+    [[nodiscard]] Chars                    GetTextChars(const std::u32string& text);
+    [[nodiscard]] gfx:: FramePoint         GetKerning(const Char& left_char, const Char& right_char) const;
+    [[nodiscard]] uint32_t                 GetLineHeight() const;
+    [[nodiscard]] const gfx::FrameSize&    GetMaxGlyphSize() const noexcept { return m_max_glyph_size; }
+    [[nodiscard]] const gfx::FrameSize&    GetAtlasSize() const noexcept;
+    [[nodiscard]] const Ptr<gfx::Texture>& GetAtlasTexturePtr(gfx::Context& context);
+    [[nodiscard]] gfx::Texture&            GetAtlasTexture(gfx::Context& context);
 
 protected:
     // Font can be created only via Font::Library::Add

--- a/Modules/UserInterface/Typography/Include/Methane/UserInterface/Text.h
+++ b/Modules/UserInterface/Typography/Include/Methane/UserInterface/Text.h
@@ -30,6 +30,8 @@ Methane text rendering primitive.
 #include <Methane/Graphics/Color.hpp>
 #include <Methane/Data/Receiver.hpp>
 
+#include <string_view>
+
 namespace Methane::Graphics
 {
 struct RenderContext;
@@ -114,10 +116,10 @@ public:
     [[nodiscard]] const std::u32string& GetTextUtf32() const noexcept { return m_settings.text; }
     [[nodiscard]] std::string           GetTextUtf8() const;
 
-    void SetText(const std::string& text);
-    void SetText(const std::u32string& text);
-    void SetTextInScreenRect(const std::string& text, const UnitRect& ui_rect);
-    void SetTextInScreenRect(const std::u32string& text, const UnitRect& ui_rect);
+    void SetText(std::string_view text);
+    void SetText(std::u32string_view text);
+    void SetTextInScreenRect(std::string_view text, const UnitRect& ui_rect);
+    void SetTextInScreenRect(std::u32string_view text, const UnitRect& ui_rect);
     void SetColor(const gfx::Color4f& color);
     void SetLayout(const Layout& layout);
     void SetWrap(Wrap wrap);
@@ -168,8 +170,8 @@ private:
         [[nodiscard]] gfx::ProgramBindings& GetProgramBindings() const;
 
         bool UpdateAtlasTexture(const Ptr<gfx::Texture>& new_atlas_texture_ptr); // returns true if probram bindings were updated, false if bindings have to be initialized
-        void UpdateMeshBuffers(gfx::RenderContext& render_context, const TextMesh& text_mesh, const std::string& text_name, Data::Size reservation_multiplier);
-        void UpdateUniformsBuffer(gfx::RenderContext& render_context, const TextMesh& text_mesh, const std::string& text_name);
+        void UpdateMeshBuffers(gfx::RenderContext& render_context, const TextMesh& text_mesh, std::string_view text_name, Data::Size reservation_multiplier);
+        void UpdateUniformsBuffer(gfx::RenderContext& render_context, const TextMesh& text_mesh, std::string_view text_name);
         void InitializeProgramBindings(const gfx::RenderState& state, const Ptr<gfx::Buffer>& const_buffer_ptr, const Ptr<gfx::Sampler>& atlas_sampler_ptr);
 
     private:

--- a/Modules/UserInterface/Typography/Include/Methane/UserInterface/Text.h
+++ b/Modules/UserInterface/Typography/Include/Methane/UserInterface/Text.h
@@ -154,7 +154,7 @@ private:
             All      = ~0U
         };
 
-        FrameResources(const gfx::RenderState& state, gfx::RenderContext& render_context,
+        FrameResources(gfx::RenderContext& render_context, const gfx::RenderState& render_state,
                        const Ptr<gfx::Buffer>& const_buffer_ptr, const Ptr<gfx::Texture>& atlas_texture_ptr, const Ptr<gfx::Sampler>& atlas_sampler_ptr,
                        const TextMesh& text_mesh, const std::string& text_name, Data::Size reservation_multiplier);
 

--- a/Modules/UserInterface/Typography/Include/Methane/UserInterface/Text.h
+++ b/Modules/UserInterface/Typography/Include/Methane/UserInterface/Text.h
@@ -80,6 +80,7 @@ public:
         HorizontalAlignment horizontal_alignment = HorizontalAlignment::Left;
         VerticalAlignment   vertical_alignment   = VerticalAlignment::Top;
 
+        [[nodiscard]]
         bool operator==(const Layout& other) const noexcept
         {
             return std::tie(wrap, horizontal_alignment, vertical_alignment) ==
@@ -109,9 +110,9 @@ public:
     Text(Context& ui_context, Font& font, SettingsUtf32 settings);
     ~Text() override;
 
-    const SettingsUtf32&  GetSettings() const noexcept            { return m_settings; }
-    const std::u32string& GetTextUtf32() const noexcept           { return m_settings.text; }
-    std::string           GetTextUtf8() const;
+    [[nodiscard]] const SettingsUtf32&  GetSettings() const noexcept  { return m_settings; }
+    [[nodiscard]] const std::u32string& GetTextUtf32() const noexcept { return m_settings.text; }
+    [[nodiscard]] std::string           GetTextUtf8() const;
 
     void SetText(const std::string& text);
     void SetText(const std::u32string& text);
@@ -156,14 +157,15 @@ private:
                        const TextMesh& text_mesh, const std::string& text_name, Data::Size reservation_multiplier);
 
         void SetDirty(DirtyFlags dirty_flags) noexcept;
-        bool IsDirty(DirtyFlags dirty_flags) const noexcept;
-        bool IsDirty() const noexcept                           { return m_dirty_mask != DirtyFlags::None; }
-        bool IsInitialized() const noexcept                     { return m_program_bindings_ptr && m_vertex_buffer_set_ptr && m_index_buffer_ptr; }
-        bool IsAtlasInitialized() const noexcept                { return !!m_atlas_texture_ptr; }
 
-        gfx::BufferSet&       GetVertexBufferSet() const;
-        gfx::Buffer&          GetIndexBuffer() const;
-        gfx::ProgramBindings& GetProgramBindings() const;
+        [[nodiscard]] bool IsDirty(DirtyFlags dirty_flags) const noexcept;
+        [[nodiscard]] bool IsDirty() const noexcept                           { return m_dirty_mask != DirtyFlags::None; }
+        [[nodiscard]] bool IsInitialized() const noexcept                     { return m_program_bindings_ptr && m_vertex_buffer_set_ptr && m_index_buffer_ptr; }
+        [[nodiscard]] bool IsAtlasInitialized() const noexcept                { return !!m_atlas_texture_ptr; }
+
+        [[nodiscard]] gfx::BufferSet&       GetVertexBufferSet() const;
+        [[nodiscard]] gfx::Buffer&          GetIndexBuffer() const;
+        [[nodiscard]] gfx::ProgramBindings& GetProgramBindings() const;
 
         bool UpdateAtlasTexture(const Ptr<gfx::Texture>& new_atlas_texture_ptr); // returns true if probram bindings were updated, false if bindings have to be initialized
         void UpdateMeshBuffers(gfx::RenderContext& render_context, const TextMesh& text_mesh, const std::string& text_name, Data::Size reservation_multiplier);

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
@@ -251,12 +251,12 @@ public:
     bool TryPack(const Refs<Font::Char>& font_chars)
     {
         META_FUNCTION_TASK();
-        for(const Ref<Font::Char>& font_char : font_chars)
-        {
-            if (!TryPack(font_char.get()))
-                return false;
-        }
-        return true;
+        return std::all_of(font_chars.begin(), font_chars.end(),
+            [this](const Ref<Font::Char>& font_char)
+            {
+                return TryPack(font_char.get());
+            }
+        );
     }
 
     bool TryPack(Font::Char& font_char)

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
@@ -229,7 +229,7 @@ private:
         FT_Face ft_face = nullptr;
 
         ThrowFreeTypeError(FT_New_Memory_Face(ft_library,
-            font_data.GetDataPtr(),
+            reinterpret_cast<const FT_Byte*>(font_data.GetDataPtr()),
             static_cast<FT_Long>(font_data.GetDataSize()), 0,
             &ft_face));
 
@@ -686,8 +686,8 @@ bool Font::UpdateAtlasBitmap(bool deferred_textures_update)
         return false;
 
     // Clear old atlas content
-    std::fill(m_atlas_bitmap.begin(), m_atlas_bitmap.end(), uint8_t(0));
-    m_atlas_bitmap.resize(atlas_size.GetPixelsCount(), uint8_t(0));
+    std::fill(m_atlas_bitmap.begin(), m_atlas_bitmap.end(), Data::Byte{});
+    m_atlas_bitmap.resize(atlas_size.GetPixelsCount(), Data::Byte{});
 
     // Render glyphs to atlas bitmap
     for (const auto& code_and_char : m_char_by_code)
@@ -845,7 +845,9 @@ void Font::Char::DrawToAtlas(Data::Bytes& atlas_bitmap, uint32_t atlas_row_strid
     {
         const uint32_t atlas_index = m_rect.origin.GetX() + (m_rect.origin.GetY() + y) * atlas_row_stride;
         META_CHECK_ARG_LESS_DESCR(atlas_index, atlas_bitmap.size() - ft_bitmap.width + 1, "char glyph does not fit into target atlas bitmap");
-        std::copy(ft_bitmap.buffer + y * ft_bitmap.width, ft_bitmap.buffer + (y + 1) * ft_bitmap.width, atlas_bitmap.begin() + atlas_index);
+        std::copy(reinterpret_cast<Data::RawPtr>(ft_bitmap.buffer + y * ft_bitmap.width),
+                  reinterpret_cast<Data::RawPtr>(ft_bitmap.buffer + (y + 1) * ft_bitmap.width),
+                  atlas_bitmap.begin() + atlas_index);
     }
 }
 

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
@@ -229,7 +229,7 @@ private:
         FT_Face ft_face = nullptr;
 
         ThrowFreeTypeError(FT_New_Memory_Face(ft_library,
-            reinterpret_cast<const FT_Byte*>(font_data.GetDataPtr()),
+            reinterpret_cast<const FT_Byte*>(font_data.GetDataPtr()), // NOSONAR
             static_cast<FT_Long>(font_data.GetDataSize()), 0,
             &ft_face));
 

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
@@ -314,7 +314,7 @@ Font& Font::Library::GetFont(const Data::Provider& data_provider, const Settings
 Font& Font::Library::AddFont(const Data::Provider& data_provider, const Settings& font_settings)
 {
     META_FUNCTION_TASK();
-    auto [ name_and_font_it, font_added ] = m_font_by_name.try_emplace(font_settings.description.name, new Font(data_provider, font_settings));
+    auto [ name_and_font_it, font_added ] = m_font_by_name.try_emplace(font_settings.description.name, new Font(data_provider, font_settings)); // NOSONAR
     META_CHECK_ARG_DESCR(font_settings.description.name, font_added, "font with a give name already exists in fonts library");
 
     META_CHECK_ARG_NAME("emplace_result", name_and_font_it->second);

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
@@ -304,12 +304,11 @@ Font& Font::Library::GetFont(const Data::Provider& data_provider, const Settings
 {
     META_FUNCTION_TASK();
     const auto font_by_name_it = m_font_by_name.find(font_settings.description.name);
-    if (font_by_name_it != m_font_by_name.end())
-    {
-        META_CHECK_ARG_NOT_NULL(font_by_name_it->second);
-        return *font_by_name_it->second;
-    }
-    return AddFont(data_provider, font_settings);
+    if (font_by_name_it == m_font_by_name.end())
+        return AddFont(data_provider, font_settings);
+
+    META_CHECK_ARG_NOT_NULL(font_by_name_it->second);
+    return *font_by_name_it->second;
 }
 
 Font& Font::Library::AddFont(const Data::Provider& data_provider, const Settings& font_settings)
@@ -469,8 +468,7 @@ void Font::AddChars(const std::u32string& utf32_characters)
 const Font::Char& Font::AddChar(Char::Code char_code)
 {
     META_FUNCTION_TASK();
-    const Char& font_char = GetChar(char_code);
-    if (font_char)
+    if (const Char& font_char = GetChar(char_code); font_char)
         return font_char;
 
     // Load char glyph and add it to the font characters map
@@ -508,8 +506,8 @@ const Font::Char& Font::GetChar(Char::Code char_code) const
 {
     META_FUNCTION_TASK();
     static const Char s_none_char {};
-    static const Char s_line_break(static_cast<Char::Code>('\n'));
-    if (char_code == s_line_break.GetCode())
+    if (static const Char s_line_break(static_cast<Char::Code>('\n'));
+        char_code == s_line_break.GetCode())
         return s_line_break;
 
     const auto char_by_code_it = m_char_by_code.find(char_code);
@@ -617,8 +615,8 @@ bool Font::PackCharsToAtlas(float pixels_reserve_multiplier)
 const Ptr<gfx::Texture>& Font::GetAtlasTexturePtr(gfx::Context& context)
 {
     META_FUNCTION_TASK();
-    const auto atlas_texture_it = m_atlas_textures.find(&context);
-    if (atlas_texture_it != m_atlas_textures.end())
+    if (const auto atlas_texture_it = m_atlas_textures.find(&context);
+        atlas_texture_it != m_atlas_textures.end())
     {
         META_CHECK_ARG_NOT_NULL(atlas_texture_it->second.texture_ptr);
         return atlas_texture_it->second.texture_ptr;
@@ -730,10 +728,9 @@ void Font::UpdateAtlasTexture(gfx::Context& context, AtlasTexture& atlas_texture
     META_FUNCTION_TASK();
     META_CHECK_ARG_NOT_NULL_DESCR(atlas_texture.texture_ptr, "font atlas texture is not initialized");
 
-    const gfx::FrameSize   atlas_size         = m_atlas_pack_ptr->GetSize();
-    const gfx::Dimensions& texture_dimensions = atlas_texture.texture_ptr->GetSettings().dimensions;
-
-    if (texture_dimensions.width != atlas_size.width || texture_dimensions.height != atlas_size.height)
+    const gfx::FrameSize atlas_size = m_atlas_pack_ptr->GetSize();
+    if (const gfx::Dimensions& texture_dimensions = atlas_texture.texture_ptr->GetSettings().dimensions;
+        texture_dimensions.width != atlas_size.width || texture_dimensions.height != atlas_size.height)
     {
         const Ptr<gfx::Texture> old_texture_ptr = atlas_texture.texture_ptr;
         atlas_texture.texture_ptr = CreateAtlasTexture(context, false).texture_ptr;
@@ -773,8 +770,8 @@ void Font::OnContextReleased(gfx::Context& context)
 void Font::OnContextCompletingInitialization(gfx::Context& context)
 {
     META_FUNCTION_TASK();
-    const auto atlas_texture_it = m_atlas_textures.find(&context);
-    if (atlas_texture_it != m_atlas_textures.end() && atlas_texture_it->second.is_update_required)
+    if (const auto atlas_texture_it = m_atlas_textures.find(&context);
+        atlas_texture_it != m_atlas_textures.end() && atlas_texture_it->second.is_update_required)
     {
         UpdateAtlasTexture(context, atlas_texture_it->second);
     }

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
@@ -46,7 +46,7 @@ static constexpr int32_t g_ft_dots_in_pixel = 64; // Freetype measures all font 
 namespace Methane::UserInterface
 {
 
-static const char* GetFTErrorMessage(FT_Error err)
+[[nodiscard]] static const char* GetFTErrorMessage(FT_Error err)
 {
     META_FUNCTION_TASK();
 
@@ -93,7 +93,7 @@ public:
     Impl& operator=(const Impl&) noexcept = delete;
     Impl& operator=(Impl&&) noexcept = delete;
 
-    FT_Library GetFTLib() const { return m_ft_library; }
+    [[nodiscard]] FT_Library GetFTLib() const { return m_ft_library; }
 
 private:
     FT_Library m_ft_library;
@@ -121,8 +121,8 @@ public:
     Glyph& operator=(const Glyph&) noexcept = delete;
     Glyph& operator=(Glyph&&) noexcept = delete;
 
-    FT_Glyph GetFTGlyph() const   { return m_ft_glyph; }
-    uint32_t GetFaceIndex() const { return m_face_index; }
+    [[nodiscard]] FT_Glyph GetFTGlyph() const   { return m_ft_glyph; }
+    [[nodiscard]] uint32_t GetFaceIndex() const { return m_face_index; }
 
 private:
     const FT_Glyph m_ft_glyph;

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Font.cpp
@@ -347,18 +347,18 @@ Font::Library::Library()
     META_FUNCTION_TASK();
 }
 
-std::u32string Font::ConvertUtf8To32(const std::string& text)
+std::u32string Font::ConvertUtf8To32(std::string_view text)
 {
     META_FUNCTION_TASK();
     static std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> converter;
-    return converter.from_bytes(text);
+    return converter.from_bytes(text.data(), text.data() + text.length());
 }
 
-std::string Font::ConvertUtf32To8(const std::u32string& text)
+std::string Font::ConvertUtf32To8(std::u32string_view text)
 {
     META_FUNCTION_TASK();
     static std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> converter;
-    return converter.to_bytes(text);
+    return converter.to_bytes(text.data(), text.data() + text.length());
 }
 
 std::u32string Font::GetAlphabetInRange(char32_t from, char32_t to)

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
@@ -215,8 +215,8 @@ void Text::SetTextInScreenRect(std::u32string_view text, const UnitRect& ui_rect
     if (m_frame_resources.empty())
         return;
 
-    FrameResources& frame_resources = GetCurrentFrameResources();
-    if (!frame_resources.IsAtlasInitialized())
+    if (FrameResources& frame_resources = GetCurrentFrameResources();
+        !frame_resources.IsAtlasInitialized())
     {
         // If atlas texture was not initialized it has to be requested for current context first to be properly updated in future
         frame_resources.UpdateAtlasTexture(m_font_ptr->GetAtlasTexturePtr(GetUIContext().GetRenderContext()));

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
@@ -349,7 +349,7 @@ void Text::Draw(gfx::RenderCommandList& cmd_list, gfx::CommandList::DebugGroup* 
     if (!frame_resources.IsInitialized())
         return;
 
-    cmd_list.ResetOnceWithState(m_render_state_ptr, p_debug_group);
+    cmd_list.ResetOnceWithState(*m_render_state_ptr, p_debug_group);
     cmd_list.SetViewState(*m_view_state_ptr);
     cmd_list.SetProgramBindings(frame_resources.GetProgramBindings());
     cmd_list.SetVertexBuffers(frame_resources.GetVertexBufferSet());

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
@@ -381,7 +381,7 @@ void Text::OnFontAtlasTextureReset(Font& font, const Ptr<gfx::Texture>& old_atla
     }
 }
 
-Text::FrameResources::FrameResources(const gfx::RenderState& state, gfx::RenderContext& render_context,
+Text::FrameResources::FrameResources(gfx::RenderContext& render_context, const gfx::RenderState& render_state,
                                      const Ptr<gfx::Buffer>& const_buffer_ptr, const Ptr<gfx::Texture>& atlas_texture_ptr, const Ptr<gfx::Sampler>& atlas_sampler_ptr,
                                      const TextMesh& text_mesh, const std::string& text_name, Data::Size reservation_multiplier)
      : m_atlas_texture_ptr(atlas_texture_ptr)
@@ -389,7 +389,7 @@ Text::FrameResources::FrameResources(const gfx::RenderState& state, gfx::RenderC
     META_FUNCTION_TASK();
     UpdateMeshBuffers(render_context, text_mesh, text_name, reservation_multiplier);
     UpdateUniformsBuffer(render_context, text_mesh, text_name);
-    InitializeProgramBindings(state, const_buffer_ptr, atlas_sampler_ptr);
+    InitializeProgramBindings(render_state, const_buffer_ptr, atlas_sampler_ptr);
 }
 
 void Text::FrameResources::SetDirty(DirtyFlags dirty_flags) noexcept
@@ -563,7 +563,8 @@ void Text::InitializeFrameResources()
     for(uint32_t frame_buffer_index = 0U; frame_buffer_index < frame_buffers_count; ++frame_buffer_index)
     {
         m_frame_resources.emplace_back(
-            *m_render_state_ptr, render_context, m_const_buffer_ptr, atlas_texture_ptr, m_atlas_sampler_ptr,
+            render_context, *m_render_state_ptr,
+            m_const_buffer_ptr, atlas_texture_ptr, m_atlas_sampler_ptr,
             *m_text_mesh_ptr, m_settings.name, m_settings.mesh_buffers_reservation_multiplier
         );
     }

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
@@ -179,25 +179,25 @@ std::string Text::GetTextUtf8() const
     return Font::ConvertUtf32To8(m_settings.text);
 }
 
-void Text::SetText(const std::string& text)
+void Text::SetText(std::string_view text)
 {
     META_FUNCTION_TASK();
     SetTextInScreenRect(text, m_settings.rect);
 }
 
-void Text::SetText(const std::u32string& text)
+void Text::SetText(std::u32string_view text)
 {
     META_FUNCTION_TASK();
     SetTextInScreenRect(text, m_settings.rect);
 }
 
-void Text::SetTextInScreenRect(const std::string& text, const UnitRect& ui_rect)
+void Text::SetTextInScreenRect(std::string_view text, const UnitRect& ui_rect)
 {
     META_FUNCTION_TASK();
     SetTextInScreenRect(Font::ConvertUtf8To32(text), ui_rect);
 }
 
-void Text::SetTextInScreenRect(const std::u32string& text, const UnitRect& ui_rect)
+void Text::SetTextInScreenRect(std::u32string_view text, const UnitRect& ui_rect)
 {
     META_FUNCTION_TASK();
     const bool             text_changed  = m_settings.text != text;
@@ -469,7 +469,7 @@ bool Text::FrameResources::UpdateAtlasTexture(const Ptr<gfx::Texture>& new_atlas
 }
 
 void Text::FrameResources::UpdateMeshBuffers(gfx::RenderContext& render_context, const TextMesh& text_mesh,
-                                             const std::string& text_name, Data::Size reservation_multiplier)
+                                             std::string_view text_name, Data::Size reservation_multiplier)
 {
     META_FUNCTION_TASK();
 
@@ -481,7 +481,7 @@ void Text::FrameResources::UpdateMeshBuffers(gfx::RenderContext& render_context,
     {
         const Data::Size vertex_buffer_size = vertices_data_size * reservation_multiplier;
         Ptr<gfx::Buffer> vertex_buffer_ptr = gfx::Buffer::CreateVertexBuffer(render_context, vertex_buffer_size, text_mesh.GetVertexSize());
-        vertex_buffer_ptr->SetName(text_name + " Text Vertex Buffer");
+        vertex_buffer_ptr->SetName(fmt::format("{} Text Vertex Buffer", text_name));
         m_vertex_buffer_set_ptr = gfx::BufferSet::CreateVertexBuffers({ *vertex_buffer_ptr });
     }
     (*m_vertex_buffer_set_ptr)[0].SetData({
@@ -499,7 +499,7 @@ void Text::FrameResources::UpdateMeshBuffers(gfx::RenderContext& render_context,
     {
         const Data::Size index_buffer_size = vertices_data_size * reservation_multiplier;
         m_index_buffer_ptr = gfx::Buffer::CreateIndexBuffer(render_context, index_buffer_size, gfx::PixelFormat::R16Uint);
-        m_index_buffer_ptr->SetName(text_name + " Text Index Buffer");
+        m_index_buffer_ptr->SetName(fmt::format("{} Text Index Buffer", text_name));
     }
 
     m_index_buffer_ptr->SetData({
@@ -513,7 +513,7 @@ void Text::FrameResources::UpdateMeshBuffers(gfx::RenderContext& render_context,
     m_dirty_mask &= ~DirtyFlags::Mesh;
 }
 
-void Text::FrameResources::UpdateUniformsBuffer(gfx::RenderContext& render_context, const TextMesh& text_mesh, const std::string& text_name)
+void Text::FrameResources::UpdateUniformsBuffer(gfx::RenderContext& render_context, const TextMesh& text_mesh, std::string_view text_name)
 {
     META_FUNCTION_TASK();
 
@@ -535,7 +535,7 @@ void Text::FrameResources::UpdateUniformsBuffer(gfx::RenderContext& render_conte
     if (!m_uniforms_buffer_ptr)
     {
         m_uniforms_buffer_ptr = gfx::Buffer::CreateConstantBuffer(render_context, gfx::Buffer::GetAlignedBufferSize(uniforms_data_size));
-        m_uniforms_buffer_ptr->SetName(text_name + " Text Uniforms Buffer");
+        m_uniforms_buffer_ptr->SetName(fmt::format("{} Text Uniforms Buffer", text_name));
 
         if (m_program_bindings_ptr)
         {

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
@@ -349,7 +349,7 @@ void Text::Draw(gfx::RenderCommandList& cmd_list, gfx::CommandList::DebugGroup* 
     if (!frame_resources.IsInitialized())
         return;
 
-    cmd_list.ResetOnceWithState(*m_render_state_ptr, p_debug_group);
+    cmd_list.ResetWithStateOnce(*m_render_state_ptr, p_debug_group);
     cmd_list.SetViewState(*m_view_state_ptr);
     cmd_list.SetProgramBindings(frame_resources.GetProgramBindings());
     cmd_list.SetVertexBuffers(frame_resources.GetVertexBufferSet());

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/Text.cpp
@@ -349,7 +349,7 @@ void Text::Draw(gfx::RenderCommandList& cmd_list, gfx::CommandList::DebugGroup* 
     if (!frame_resources.IsInitialized())
         return;
 
-    cmd_list.ResetWithState(m_render_state_ptr, p_debug_group);
+    cmd_list.ResetOnceWithState(m_render_state_ptr, p_debug_group);
     cmd_list.SetViewState(*m_view_state_ptr);
     cmd_list.SetProgramBindings(frame_resources.GetProgramBindings());
     cmd_list.SetVertexBuffers(frame_resources.GetVertexBufferSet());

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/TextMesh.cpp
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/TextMesh.cpp
@@ -70,8 +70,8 @@ void ForEachTextCharacterInRange(const Font& font, const Font::Chars& text_chars
         }
 
         // Wrap to next line on text overrun of frame width
-        const uint32_t char_right_pos = char_pos.GetX() + (text_char.IsWhiteSpace() ? 0U : char_pos.visual_width);
-        if (wrap == Text::Wrap::Anywhere && frame_width && char_right_pos > frame_width)
+        if (const uint32_t char_right_pos = char_pos.GetX() + (text_char.IsWhiteSpace() ? 0U : char_pos.visual_width);
+            wrap == Text::Wrap::Anywhere && frame_width && char_right_pos > frame_width)
         {
             char_pos.SetX(0);
             char_pos.SetY(char_pos.GetY() + font.GetLineHeight());
@@ -85,8 +85,7 @@ void ForEachTextCharacterInRange(const Font& font, const Font::Chars& text_chars
         if (p_prev_text_char)
             char_pos += font.GetKerning(*p_prev_text_char, text_char);
 
-        const CharAction action = process_char_at_position(text_char, char_pos, char_index);
-        switch (action)
+        switch (const CharAction action = process_char_at_position(text_char, char_pos, char_index); action)
         {
         case CharAction::Continue:
             char_positions.emplace_back(char_pos.GetX() + text_char.GetAdvance().GetX(), char_pos.GetY());
@@ -241,10 +240,9 @@ void TextMesh::EraseTrailingChars(size_t erase_chars_count, bool fixup_whitespac
 
     if (fixup_whitespace && m_last_whitespace_index >= m_text.length())
     {
-        const auto whitespace_it = std::find_if(m_text.rbegin(), m_text.rend(),
-            [](char32_t char_code) { return char_code <= 255 && std::isspace(static_cast<int>(char_code)); }
-        );
-        if (whitespace_it != m_text.rend())
+        if (const auto whitespace_it = std::find_if(m_text.rbegin(), m_text.rend(),
+                                                    [](char32_t char_code) { return char_code <= 255 && std::isspace(static_cast<int>(char_code)); });
+            whitespace_it != m_text.rend())
         {
             m_last_whitespace_index = std::distance(m_text.begin(), whitespace_it.base()) - 1;
             META_CHECK_ARG(m_last_whitespace_index, m_char_positions[m_last_whitespace_index].is_whitespace_or_linebreak);
@@ -257,10 +255,9 @@ void TextMesh::EraseTrailingChars(size_t erase_chars_count, bool fixup_whitespac
 
     if (m_last_line_start_index >= m_text.length())
     {
-        const auto line_start_it = std::find_if(m_char_positions.rbegin(), m_char_positions.rend(),
-            [](const CharPosition& char_pos) { return char_pos.is_line_start; }
-        );
-        if (line_start_it != m_char_positions.rend())
+        if (const auto line_start_it = std::find_if(m_char_positions.rbegin(), m_char_positions.rend(),
+                                                    [](const CharPosition& char_pos) { return char_pos.is_line_start; });
+            line_start_it != m_char_positions.rend())
         {
             m_last_line_start_index = std::distance(m_char_positions.begin(), line_start_it.base()) - 1;
             META_CHECK_ARG(m_last_line_start_index, m_char_positions[m_last_line_start_index].is_line_start);

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/TextMesh.h
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/TextMesh.h
@@ -61,24 +61,24 @@ public:
 
     TextMesh(const std::u32string& text, Text::Layout layout, Font& font, gfx::FrameSize& viewport_size);
 
-    bool IsUpdatable(const std::u32string& text, const Text::Layout& layout, Font& font, const gfx::FrameSize& viewport_size) const noexcept;
+    [[nodiscard]] bool IsUpdatable(const std::u32string& text, const Text::Layout& layout, Font& font, const gfx::FrameSize& viewport_size) const noexcept;
     void Update(const std::u32string& text, gfx::FrameSize& viewport_size);
 
-    const std::u32string& GetText() const noexcept              { return m_text; }
-    Font&                 GetFont() noexcept                    { return m_font; }
-    Text::Layout          GetLayout() const noexcept            { return m_layout; }
-    const gfx::FrameSize& GetFrameSize() const noexcept         { return m_frame_size; }
-    const gfx::FrameSize& GetContentSize() const noexcept       { return m_content_size; }
-    uint32_t              GetContentTopOffset() const noexcept  { return m_content_top_offset == std::numeric_limits<uint32_t>::max() ? 0U : m_content_top_offset; }
+    [[nodiscard]] const std::u32string& GetText() const noexcept              { return m_text; }
+    [[nodiscard]] Font&                 GetFont() noexcept                    { return m_font; }
+    [[nodiscard]] Text::Layout          GetLayout() const noexcept            { return m_layout; }
+    [[nodiscard]] const gfx::FrameSize& GetFrameSize() const noexcept         { return m_frame_size; }
+    [[nodiscard]] const gfx::FrameSize& GetContentSize() const noexcept       { return m_content_size; }
+    [[nodiscard]] uint32_t              GetContentTopOffset() const noexcept  { return m_content_top_offset == std::numeric_limits<uint32_t>::max() ? 0U : m_content_top_offset; }
 
-    const Vertices& GetVertices() const noexcept                { return m_vertices; }
-    const Indices&  GetIndices() const noexcept                 { return m_indices; }
+    [[nodiscard]] const Vertices& GetVertices() const noexcept                { return m_vertices; }
+    [[nodiscard]] const Indices&  GetIndices() const noexcept                 { return m_indices; }
 
-    Data::Size      GetVertexSize() const noexcept              { return static_cast<Data::Size>(sizeof(Vertex)); }
-    Data::Size      GetVerticesDataSize() const noexcept        { return static_cast<Data::Size>(m_vertices.size() * sizeof(Vertex)); }
+    [[nodiscard]] Data::Size      GetVertexSize() const noexcept              { return static_cast<Data::Size>(sizeof(Vertex)); }
+    [[nodiscard]] Data::Size      GetVerticesDataSize() const noexcept        { return static_cast<Data::Size>(m_vertices.size() * sizeof(Vertex)); }
 
-    Data::Size      GetIndexSize() const noexcept               { return static_cast<Data::Size>(sizeof(Index)); }
-    Data::Size      GetIndicesDataSize() const noexcept         { return static_cast<Data::Size>(m_indices.size() * sizeof(Index)); }
+    [[nodiscard]] Data::Size      GetIndexSize() const noexcept               { return static_cast<Data::Size>(sizeof(Index)); }
+    [[nodiscard]] Data::Size      GetIndicesDataSize() const noexcept         { return static_cast<Data::Size>(m_indices.size() * sizeof(Index)); }
 
 private:
     void EraseTrailingChars(size_t erase_chars_count, bool fixup_whitespace, bool update_alignment_and_content_size);
@@ -89,8 +89,11 @@ private:
     void UpdateContentSize();
     void UpdateContentSizeWithChar(const Font::Char& font_char, const gfx::FramePoint& char_pos);
 
-    bool IsNewTextStartsWithOldOne(const std::u32string& text) const noexcept { return m_text.empty() || (m_text.length() < text.length()   && text.find(m_text) == 0); }
-    bool IsOldTextStartsWithNewOne(const std::u32string& text) const noexcept { return !text.empty()  &&  text.length()   < m_text.length() && m_text.find(text) == 0; }
+    [[nodiscard]] bool IsNewTextStartsWithOldOne(const std::u32string& text) const noexcept
+    { return m_text.empty() || (m_text.length() < text.length()   && text.find(m_text) == 0); }
+
+    [[nodiscard]] bool IsOldTextStartsWithNewOne(const std::u32string& text) const noexcept
+    { return !text.empty()  &&  text.length()   < m_text.length() && m_text.find(text) == 0; }
 
     std::u32string       m_text;
     Font&                m_font;

--- a/Modules/UserInterface/Typography/Sources/Methane/UserInterface/TextMesh.h
+++ b/Modules/UserInterface/Typography/Sources/Methane/UserInterface/TextMesh.h
@@ -89,10 +89,10 @@ private:
     void UpdateContentSize();
     void UpdateContentSizeWithChar(const Font::Char& font_char, const gfx::FramePoint& char_pos);
 
-    [[nodiscard]] bool IsNewTextStartsWithOldOne(const std::u32string& text) const noexcept
+    [[nodiscard]] bool IsNewTextStartsWithOldOne(std::u32string_view text) const noexcept
     { return m_text.empty() || (m_text.length() < text.length()   && text.find(m_text) == 0); }
 
-    [[nodiscard]] bool IsOldTextStartsWithNewOne(const std::u32string& text) const noexcept
+    [[nodiscard]] bool IsOldTextStartsWithNewOne(std::u32string_view text) const noexcept
     { return !text.empty()  &&  text.length()   < m_text.length() && m_text.find(text) == 0; }
 
     std::u32string       m_text;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -225,7 +225,7 @@ jobs:
     platform: 'MacOS'
     configuration: 'Debug'
     generatorName: 'Xcode'
-    cmakeFlags: $(buildScanCmakeFlags) -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+    cmakeFlags: $(buildScanCmakeFlags) -DCMAKE_OSX_ARCHITECTURES="x86_64"
     buildName: '$(platform)-$(configuration)-SonarScan'
     buildDir: 'Build/Output/$(buildName)/Build'
     installDir: 'Build/Output/$(buildName)/Install'
@@ -258,7 +258,7 @@ jobs:
                 fi
                 mv default.profraw "$test_exe$prof_raw_ext"
                 xcrun llvm-profdata merge -o "$test_exe$prof_data_ext" "$test_exe$prof_raw_ext"
-                xcrun llvm-cov export -format lcov -instr-profile="$test_exe$prof_data_ext" ./$test_exe > "./Coverage/$test_exe$lcov_ext"
+                xcrun llvm-cov export -format lcov -instr-profile="$test_exe$prof_data_ext" -arch=x86_64 ./$test_exe > "./Coverage/$test_exe$lcov_ext"
                 echo    - Converted code coverage from "$test_exe$prof_raw_ext" to lcov text format "./Coverage/$test_exe$lcov_ext", $? exit status
               done
               echo List of generated coverage files in directory $PWD/Coverage


### PR DESCRIPTION
# Methane Kit v0.5 Pre-Release Update 4

- **Globally** fixed new C++17 static analysis issues from [SonarCloud](https://sonarcloud.io/organizations/egorodet-github):
  - Use `std::map::try_emplace` instead of `std::map::emplace`
  - Use `std::byte` instead of `uint8_t` and `char` for byte-access to memory buffers
  - Use structured bindings in `for` loops over elements of `std::map`
  - Use `[[nodiscard]]` attribute for constant methods like getters
  - Use `std::string_view` in some cases for input string arguments
  - Use inline initialiser statements in `if` and `switch` statements
  - Use `scoped_lock` instead of `lock_guard`
- **UserInterface** libraries:
  - `Text` rendering is now calling `ResetWithStateOnce` instead of `ResetWithState` to minimize rendering state resets during rendering sequence of several text blocks.
- **Graphics** libraries:
  - **Graphics Core** changes
    - Add method `RenderCommandList::ResetWithStateOnce` additionally to `ResetWithState` to skip command list reset when it is already in `Encoding` state with the same `RenderState` already applied.
- **External** libraries:
  - [MagicEnum](https://github.com/Neargye/magic_enum) library was updated to v0.7.2
  - [IttApi]() library was updated to latest revision v3.18.8+